### PR TITLE
Centralize styles and scripts

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -1,0 +1,158 @@
+:root{
+  --primary:#0A2342; --bg:#F9FAFB; --ink:#1C1C1C; --muted:#6B7280;
+  --accent:#D4AF37; --border:#E5E7EB; --maxw:1160px;
+  --r-lg:24px; --r-md:16px; --space:72px; --shadow:0 18px 48px rgba(0,0,0,.12);
+}
+*{box-sizing:border-box}
+body{margin:0;font-family:'Inter',ui-sans-serif,system-ui;background:var(--bg);color:var(--ink);line-height:1.6}
+img{max-width:100%;display:block}
+a{color:inherit;text-decoration:none}
+.container{width:min(var(--maxw),92vw);margin:0 auto}
+
+/* Header */
+header{
+  position:sticky; top:0; z-index:50;
+  background:#ffffffcc; backdrop-filter:blur(8px);
+  border-bottom:1px solid var(--border);
+}
+.nav{
+  display:flex; align-items:center; justify-content:space-between;
+  gap:24px; padding:10px 0;
+}
+
+/* Marca / logo */
+.brand{ display:flex; align-items:center; }
+.brand img{
+  height:60px;       /* <= altura pedida */
+  display:block;     /* evita “respiro” de inline img */
+  filter:none;       /* <= remove sombra */
+  margin:0;          /* zera offsets */
+}
+/* Se a imagem tiver bordinha dentro do PNG e “descentralizar”, pode usar este ajuste fino: */
+/* .brand img{ margin-left:-6px; } */
+
+/* Menu */
+nav ul{ list-style:none; display:flex; gap:18px; margin:0; padding:0; align-items:center; }
+nav a{ padding:10px 12px; border-radius:12px; transition:background .2s; }
+nav a:hover{ background:#0000000f; }
+
+/* Hero */
+.hero{position:relative;min-height:100svh;display:grid;place-items:center;padding:88px 0}
+.hero::before{
+  content:"";position:absolute;inset:0;z-index:-1;
+  background:url('hero.jpg') center/cover no-repeat,
+             radial-gradient(1000px 600px at 10% 0%, rgba(212,175,55,.18), transparent 60%),
+             radial-gradient(900px 520px at 100% 10%, rgba(10,35,66,.25), transparent 60%);
+  opacity:.28;
+}
+.hero-card{width:min(var(--maxw),92vw);display:grid;grid-template-columns:1.15fr .85fr;gap:clamp(16px,3.6vw,32px);
+  background:#ffffffd2;border:1px solid var(--border);border-radius:var(--r-lg);box-shadow:0 30px 80px rgba(0,0,0,.16);
+  padding:clamp(22px,4vw,40px);backdrop-filter:blur(6px)}
+.kicker{text-transform:uppercase;letter-spacing:.16em;font-size:12px;color:var(--muted);margin-bottom:6px}
+.hero-title{font-size:clamp(32px,5.4vw,56px);line-height:1.06;margin:0 0 10px;color:var(--primary)}
+.hero-sub{font-size:clamp(15px,1.8vw,18px);color:var(--muted);margin:0 0 16px}
+.btn{display:inline-flex;align-items:center;gap:10px;padding:12px 18px;border-radius:12px;font-weight:700;cursor:pointer;border:1px solid var(--border);background:#fff}
+.btn.primary{background:var(--primary);color:#fff;box-shadow:0 6px 18px rgba(10,35,66,.20)}
+.btn.primary:hover{transform:translateY(-1px) scale(1.01);box-shadow:0 10px 28px rgba(10,35,66,.28)}
+.hero-photo{border-radius:18px;overflow:hidden;border:1px solid var(--border);aspect-ratio:4/3}
+.hero-photo img{width:100%;height:100%;object-fit:cover}
+
+/* Seções */
+section{padding:var(--space) 0}
+.section-title{font-size:clamp(22px,2.8vw,30px);color:var(--primary);margin:0 0 8px}
+.section-sub{color:var(--muted);margin:0 0 20px}
+.card{background:#fff;border:1px solid var(--border);border-radius:var(--r-md);padding:18px;box-shadow:0 1px 2px rgba(0,0,0,.04)}
+.grid{display:grid;gap:16px}
+.grid-2{grid-template-columns:1.2fr .8fr}
+.grid-3{grid-template-columns:repeat(3,1fr)}
+@media (max-width: 960px){ .hero-card{grid-template-columns:1fr}.grid-2,.grid-3{grid-template-columns:1fr} }
+
+/* Serviços */
+.service h3{margin:10px 0 6px;display:flex;align-items:center;gap:8px}
+.service h3 i{color:var(--accent)}
+.service p{margin:0 0 10px;color:var(--muted)}
+.service ul{list-style:none;padding:0;margin:0;display:grid;gap:6px;color:var(--muted)}
+.svc-media{height:160px;border-radius:12px;border:1px solid var(--border);overflow:hidden}
+.svc-media img{width:100%;height:100%;object-fit:cover}
+
+/* Timeline */
+.timeline{position:relative;display:grid;grid-template-columns:repeat(3,1fr);gap:24px;margin-top:10px}
+.timeline::before{content:"";position:absolute;top:28px;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--accent),transparent);opacity:.6}
+.step{position:relative;padding-top:56px;text-align:center}
+.step .dot{position:absolute;top:20px;left:50%;transform:translateX(-50%);width:16px;height:16px;background:var(--accent);border-radius:999px;box-shadow:0 0 0 6px rgba(212,175,55,.18)}
+.step h4{margin:0 0 6px}.step p{margin:0;color:var(--muted)}
+.step h4 i{color:var(--accent)}
+
+/* Benefícios */
+.benefits-head{display:flex;align-items:end;justify-content:space-between;gap:16px;margin-bottom:18px}
+.benefits-grid{display:grid;gap:16px;grid-template-columns:repeat(4,1fr)}
+.benefit{background:#fff;border:1px solid var(--border);border-radius:16px;padding:18px;box-shadow:0 1px 2px rgba(0,0,0,.04);display:grid;gap:8px}
+.benefit i{color:var(--accent);font-size:22px}
+.benefit h3{margin:0;font-size:16px;color:var(--primary)}
+.benefit p{margin:0;color:var(--muted)}
+@media (max-width:1024px){ .benefits-grid{grid-template-columns:repeat(2,1fr)} }
+@media (max-width:580px){ .benefits-grid{grid-template-columns:1fr} .benefits-head{flex-direction:column;align-items:flex-start} }
+
+/* CTA + Footer */
+.cta-card{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:18px;border-radius:16px;border:1px solid var(--border);background:#fff;box-shadow:var(--shadow)}
+@media (max-width:700px){ .cta-card{flex-direction:column;align-items:flex-start} }
+
+footer{margin-top:10px;border-top:1px solid var(--border);background:#fff}
+.footer-top{border-bottom:1px solid var(--border);padding:18px 0}
+.footer-grid{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:16px}
+.footer-col h5{margin:0 0 8px;color:var(--primary);font-size:14px}
+.footer-col a{display:block;padding:4px 0;color:var(--muted)}
+.footer-bottom{padding:14px 0;color:var(--muted);font-size:14px;display:flex;justify-content:space-between;gap:12px;flex-wrap:wrap}
+@media (max-width:900px){ .footer-grid{grid-template-columns:1fr 1fr} }
+@media (max-width:600px){ .footer-grid{grid-template-columns:1fr} }
+
+/* Animações suaves */
+.reveal{opacity:1;transform:none}
+@media (prefers-reduced-motion: no-preference){
+  .reveal{opacity:.001; transform:translateY(12px); will-change:opacity,transform}
+  .reveal.show{opacity:1; transform:none; transition:opacity .6s cubic-bezier(.22,.61,.36,1), transform .6s cubic-bezier(.22,.61,.36,1)}
+  .fade-img{opacity:.001; transform:translateY(6px); filter:saturate(.96); will-change:opacity,transform}
+  .fade-img.loaded{opacity:1; transform:none; filter:saturate(1); transition:opacity .5s cubic-bezier(.22,.61,.36,1), transform .5s cubic-bezier(.22,.61,.36,1), filter .6s ease}
+}
+
+/* Páginas internas */
+body.contato,
+body.obrigado,
+body.politicas{ --maxw:900px; }
+
+body.contato main,
+body.obrigado main,
+body.politicas main{padding:28px 0}
+
+body.contato .card,
+body.politicas .card{border-radius:20px;box-shadow:var(--shadow);padding:22px}
+body.obrigado .card{background:#fff;border:1px solid var(--border);border-radius:20px;box-shadow:var(--shadow);padding:24px;text-align:center;position:relative;overflow:hidden}
+
+body.contato .hint{display:flex;align-items:center;gap:8px;color:var(--muted)}
+body.contato h1,
+body.politicas h1{color:var(--primary);margin:8px 0 6px}
+body.politicas h2{margin:10px 0 6px;color:var(--primary);font-size:20px;display:flex;gap:8px;align-items:center}
+body.politicas .muted{color:var(--muted)}
+body.politicas ul{margin:8px 0 0;padding-left:18px;color:var(--muted)}
+body.politicas .card + .card{margin-top:18px}
+
+body.contato p.lead{color:var(--muted);margin:0 0 16px}
+body.obrigado .title{font-size:clamp(26px,4vw,34px);color:var(--primary);margin:6px 0 8px}
+body.obrigado .lead{color:var(--muted);margin:0 auto 18px;max-width:56ch}
+
+body.contato form{display:grid;gap:12px;margin-top:6px}
+body.contato input,
+body.contato textarea{padding:12px;border-radius:12px;border:1px solid var(--border);background:#fff;font:inherit;color:var(--ink);width:100%}
+body.contato textarea{min-height:140px;resize:vertical}
+body.contato button{padding:12px 18px;border-radius:12px;border:0;background:var(--primary);color:#fff;font-weight:700;cursor:pointer;box-shadow:0 6px 18px rgba(10,35,66,.20);transition:transform .08s, box-shadow .12s}
+body.contato button:hover{transform:translateY(-1px) scale(1.01);box-shadow:0 10px 28px rgba(10,35,66,.28)}
+body.contato .meta{display:flex;gap:16px;flex-wrap:wrap;color:var(--muted);font-size:14px;margin-top:10px}
+
+body.obrigado .btn{padding:12px 18px;border-radius:12px;border:1px solid var(--border);background:#fff;font-weight:700}
+body.obrigado .btn.primary{background:var(--primary);color:#fff}
+body.obrigado .confetti{position:absolute;inset:0;pointer-events:none;opacity:.08;background:radial-gradient(6px 6px at 20% 30%, var(--accent), transparent 60%),radial-gradient(6px 6px at 70% 25%, var(--primary), transparent 60%),radial-gradient(6px 6px at 85% 70%, var(--accent), transparent 60%),radial-gradient(6px 6px at 30% 75%, var(--primary), transparent 60%);filter:blur(.2px)}
+body.obrigado .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+
+body.contato footer,
+body.obrigado footer,
+body.politicas footer{margin-top:28px}

--- a/assets/main.js
+++ b/assets/main.js
@@ -1,0 +1,17 @@
+// scroll suave só para âncoras internas
+document.addEventListener('click',(e)=>{
+  const a=e.target.closest('a[href^="#"]');
+  if(!a) return;
+  const id=a.getAttribute('href');
+  if(id.length>1){
+    e.preventDefault();
+    const el=document.querySelector(id);
+    if(el) el.scrollIntoView({behavior:'smooth',block:'start'});
+  }
+});
+
+// reveal
+const io=new IntersectionObserver((entries)=>{
+  entries.forEach(en=>{if(en.isIntersecting) en.target.classList.add('show')});
+},{threshold:.12});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));

--- a/contato.html
+++ b/contato.html
@@ -32,68 +32,9 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/remixicon/fonts/remixicon.css" rel="stylesheet">
-
-  <style>
-    :root{
-      --primary:#0A2342; --bg:#F9FAFB; --ink:#1C1C1C; --muted:#6B7280;
-      --accent:#D4AF37; --border:#E5E7EB; --maxw:900px; --shadow:0 18px 48px rgba(0,0,0,.12)
-    }
-    *{box-sizing:border-box}
-    body{margin:0;font-family:'Inter',ui-sans-serif,system-ui;background:var(--bg);color:var(--ink);line-height:1.6}
-    a{text-decoration:none;color:inherit}
-    .container{width:min(var(--maxw),92vw);margin:0 auto}
-
-    /* Header */
-    header{
-      position:sticky; top:0; z-index:50;
-      background:#ffffffcc; backdrop-filter:blur(8px);
-      border-bottom:1px solid var(--border);
-    }
-    .nav{
-      display:flex; align-items:center; justify-content:space-between;
-      gap:24px; padding:10px 0;
-    }
-    /* Marca / logo */
-    .brand{ display:flex; align-items:center; }
-    .brand img{
-      height:60px;
-      display:block;
-      filter:none;
-      margin:0;
-    }
-    /* Menu */
-    nav ul{ list-style:none; display:flex; gap:18px; margin:0; padding:0; align-items:center; }
-    nav a{ padding:10px 12px; border-radius:12px; transition:background .2s; }
-    nav a:hover{ background:#0000000f; }
-
-    /* Conteúdo */
-    main{padding:28px 0}
-    .card{background:#fff;border:1px solid var(--border);border-radius:20px;box-shadow:var(--shadow);padding:22px}
-    .hint{display:flex;align-items:center;gap:8px;color:var(--muted)}
-    h1{color:var(--primary);margin:8px 0 6px;font-size:clamp(26px,4vw,34px)}
-    p.lead{color:var(--muted);margin:0 0 16px}
-    form{display:grid;gap:12px;margin-top:6px}
-    input,textarea{padding:12px;border-radius:12px;border:1px solid var(--border);background:#fff;font:inherit;color:var(--ink);width:100%}
-    textarea{min-height:140px;resize:vertical}
-    button{
-      padding:12px 18px;border-radius:12px;border:0;background:var(--primary);color:#fff;font-weight:700;cursor:pointer;
-      box-shadow:0 6px 18px rgba(10,35,66,.20); transition:transform .08s, box-shadow .12s
-    }
-    button:hover{transform:translateY(-1px) scale(1.01);box-shadow:0 10px 28px rgba(10,35,66,.28)}
-    .meta{display:flex;gap:16px;flex-wrap:wrap;color:var(--muted);font-size:14px;margin-top:10px}
-
-    /* Footer */
-    footer{margin-top:28px;border-top:1px solid var(--border);background:#fff}
-    .footer-top{border-bottom:1px solid var(--border);padding:18px 0}
-    .footer-grid{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:16px}
-    .footer-col h5{margin:0 0 8px;color:var(--primary);font-size:14px}
-    .footer-col a{display:block;padding:4px 0;color:var(--muted)}
-    .footer-bottom{padding:14px 0;color:var(--muted);font-size:14px;display:flex;justify-content:space-between;gap:12px;flex-wrap:wrap}
-    @media (max-width:900px){ .footer-grid{grid-template-columns:1fr 1fr} }
-    @media (max-width:600px){ .footer-grid{grid-template-columns:1fr} }
-  </style>
+  <link rel="stylesheet" href="/assets/main.css">
 </head>
-<body>
+<body class="contato">
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">

--- a/index.html
+++ b/index.html
@@ -40,123 +40,7 @@
     "logo": "https://munnius.com.br/assets/logo.png"
   }
   </script>
-
-  <style>
-    :root{
-      --primary:#0A2342; --bg:#F9FAFB; --ink:#1C1C1C; --muted:#6B7280;
-      --accent:#D4AF37; --border:#E5E7EB; --maxw:1160px;
-      --r-lg:24px; --r-md:16px; --space:72px; --shadow:0 18px 48px rgba(0,0,0,.12);
-    }
-    *{box-sizing:border-box}
-    body{margin:0;font-family:'Inter',ui-sans-serif,system-ui;background:var(--bg);color:var(--ink);line-height:1.6}
-    img{max-width:100%;display:block}
-    a{color:inherit;text-decoration:none}
-    .container{width:min(var(--maxw),92vw);margin:0 auto}
-
-    /* Header */
-header{
-  position:sticky; top:0; z-index:50;
-  background:#ffffffcc; backdrop-filter:blur(8px);
-  border-bottom:1px solid var(--border);
-}
-.nav{
-  display:flex; align-items:center; justify-content:space-between;
-  gap:24px; padding:10px 0;
-}
-
-    /* Marca / logo */
-    .brand{ display:flex; align-items:center; }
-    .brand img{
-      height:60px;       /* <= altura pedida */
-      display:block;     /* evita “respiro” de inline img */
-      filter:none;       /* <= remove sombra */
-      margin:0;          /* zera offsets */
-    }
-    /* Se a imagem tiver bordinha dentro do PNG e “descentralizar”, pode usar este ajuste fino: */
-    /* .brand img{ margin-left:-6px; } */
-    
-    /* Menu */
-    nav ul{ list-style:none; display:flex; gap:18px; margin:0; padding:0; align-items:center; }
-    nav a{ padding:10px 12px; border-radius:12px; transition:background .2s; }
-    nav a:hover{ background:#0000000f; }
-
-    /* Hero */
-    .hero{position:relative;min-height:100svh;display:grid;place-items:center;padding:88px 0}
-    .hero::before{
-      content:"";position:absolute;inset:0;z-index:-1;
-      background:url('assets/hero.jpg') center/cover no-repeat,
-                 radial-gradient(1000px 600px at 10% 0%, rgba(212,175,55,.18), transparent 60%),
-                 radial-gradient(900px 520px at 100% 10%, rgba(10,35,66,.25), transparent 60%);
-      opacity:.28;
-    }
-    .hero-card{width:min(var(--maxw),92vw);display:grid;grid-template-columns:1.15fr .85fr;gap:clamp(16px,3.6vw,32px);
-      background:#ffffffd2;border:1px solid var(--border);border-radius:var(--r-lg);box-shadow:0 30px 80px rgba(0,0,0,.16);
-      padding:clamp(22px,4vw,40px);backdrop-filter:blur(6px)}
-    .kicker{text-transform:uppercase;letter-spacing:.16em;font-size:12px;color:var(--muted);margin-bottom:6px}
-    .hero-title{font-size:clamp(32px,5.4vw,56px);line-height:1.06;margin:0 0 10px;color:var(--primary)}
-    .hero-sub{font-size:clamp(15px,1.8vw,18px);color:var(--muted);margin:0 0 16px}
-    .btn{display:inline-flex;align-items:center;gap:10px;padding:12px 18px;border-radius:12px;font-weight:700;cursor:pointer;border:1px solid var(--border);background:#fff}
-    .btn.primary{background:var(--primary);color:#fff;box-shadow:0 6px 18px rgba(10,35,66,.20)}
-    .btn.primary:hover{transform:translateY(-1px) scale(1.01);box-shadow:0 10px 28px rgba(10,35,66,.28)}
-    .hero-photo{border-radius:18px;overflow:hidden;border:1px solid var(--border);aspect-ratio:4/3}
-    .hero-photo img{width:100%;height:100%;object-fit:cover}
-
-    /* Seções */
-    section{padding:var(--space) 0}
-    .section-title{font-size:clamp(22px,2.8vw,30px);color:var(--primary);margin:0 0 8px}
-    .section-sub{color:var(--muted);margin:0 0 20px}
-    .card{background:#fff;border:1px solid var(--border);border-radius:var(--r-md);padding:18px;box-shadow:0 1px 2px rgba(0,0,0,.04)}
-    .grid{display:grid;gap:16px}
-    .grid-2{grid-template-columns:1.2fr .8fr}
-    .grid-3{grid-template-columns:repeat(3,1fr)}
-    @media (max-width: 960px){ .hero-card{grid-template-columns:1fr}.grid-2,.grid-3{grid-template-columns:1fr} }
-
-    /* Serviços */
-    .service h3{margin:10px 0 6px;display:flex;align-items:center;gap:8px}
-    .service h3 i{color:var(--accent)}
-    .service p{margin:0 0 10px;color:var(--muted)}
-    .service ul{list-style:none;padding:0;margin:0;display:grid;gap:6px;color:var(--muted)}
-    .svc-media{height:160px;border-radius:12px;border:1px solid var(--border);overflow:hidden}
-    .svc-media img{width:100%;height:100%;object-fit:cover}
-
-    /* Timeline */
-    .timeline{position:relative;display:grid;grid-template-columns:repeat(3,1fr);gap:24px;margin-top:10px}
-    .timeline::before{content:"";position:absolute;top:28px;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--accent),transparent);opacity:.6}
-    .step{position:relative;padding-top:56px;text-align:center}
-    .step .dot{position:absolute;top:20px;left:50%;transform:translateX(-50%);width:16px;height:16px;background:var(--accent);border-radius:999px;box-shadow:0 0 0 6px rgba(212,175,55,.18)}
-    .step h4{margin:0 0 6px}.step p{margin:0;color:var(--muted)}
-    .step h4 i{color:var(--accent)}
-
-    /* Benefícios (seção própria) */
-    .benefits-head{display:flex;align-items:end;justify-content:space-between;gap:16px;margin-bottom:18px}
-    .benefits-grid{display:grid;gap:16px;grid-template-columns:repeat(4,1fr)}
-    .benefit{background:#fff;border:1px solid var(--border);border-radius:16px;padding:18px;box-shadow:0 1px 2px rgba(0,0,0,.04);display:grid;gap:8px}
-    .benefit i{color:var(--accent);font-size:22px}
-    .benefit h3{margin:0;font-size:16px;color:var(--primary)}
-    .benefit p{margin:0;color:var(--muted)}
-    @media (max-width:1024px){ .benefits-grid{grid-template-columns:repeat(2,1fr)} }
-    @media (max-width:580px){ .benefits-grid{grid-template-columns:1fr} .benefits-head{flex-direction:column;align-items:flex-start} }
-
-    /* CTA + Footer */
-    .cta-card{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:18px;border-radius:16px;border:1px solid var(--border);background:#fff;box-shadow:var(--shadow)}
-    @media (max-width:700px){ .cta-card{flex-direction:column;align-items:flex-start} }
-
-    footer{margin-top:10px;border-top:1px solid var(--border);background:#fff}
-    .footer-top{border-bottom:1px solid var(--border);padding:18px 0}
-    .footer-grid{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:16px}
-    .footer-col h5{margin:0 0 8px;color:var(--primary);font-size:14px}
-    .footer-col a{display:block;padding:4px 0;color:var(--muted)}
-    .footer-bottom{padding:14px 0;color:var(--muted);font-size:14px;display:flex;justify-content:space-between;gap:12px;flex-wrap:wrap}
-
-    /* Animações suaves */
-    .reveal{opacity:1;transform:none}
-    @media (prefers-reduced-motion: no-preference){
-      .reveal{opacity:.001; transform:translateY(12px); will-change:opacity,transform}
-      .reveal.show{opacity:1; transform:none; transition:opacity .6s cubic-bezier(.22,.61,.36,1), transform .6s cubic-bezier(.22,.61,.36,1)}
-      .fade-img{opacity:.001; transform:translateY(6px); filter:saturate(.96); will-change:opacity,transform}
-      .fade-img.loaded{opacity:1; transform:none; filter:saturate(1); transition:opacity .5s cubic-bezier(.22,.61,.36,1), transform .5s cubic-bezier(.22,.61,.36,1), filter .6s ease}
-    }
-  </style>
+  <link rel="stylesheet" href="/assets/main.css">
 </head>
 <body>
   <!-- Header -->
@@ -365,17 +249,6 @@ header{
       <span><a href="/contato.html" rel="nofollow">Fale conosco</a></span>
     </div>
   </footer>
-
-  <script>
-    // scroll suave só para âncoras internas
-    document.addEventListener('click',(e)=>{
-      const a=e.target.closest('a[href^="#"]'); if(!a) return;
-      const id=a.getAttribute('href'); if(id.length>1){ e.preventDefault(); const el=document.querySelector(id); if(el) el.scrollIntoView({behavior:'smooth',block:'start'}); }
-    });
-
-    // reveal
-    const io=new IntersectionObserver((entries)=>{entries.forEach(en=>{if(en.isIntersecting) en.target.classList.add('show')})},{threshold:.12});
-    document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
-  </script>
+  <script src="/assets/main.js" defer></script>
 </body>
 </html>

--- a/obrigado.html
+++ b/obrigado.html
@@ -21,77 +21,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/remixicon/fonts/remixicon.css" rel="stylesheet">
-
-  <style>
-    :root{ --primary:#0A2342; --bg:#F9FAFB; --ink:#1C1C1C; --muted:#6B7280; --accent:#D4AF37; --border:#E5E7EB; --maxw:900px; --shadow:0 18px 48px rgba(0,0,0,.12) }
-    *{box-sizing:border-box}
-    body{margin:0;font-family:'Inter',ui-sans-serif,system-ui;background:var(--bg);color:var(--ink);line-height:1.6}
-    a{text-decoration:none;color:inherit}
-    .container{width:min(var(--maxw),92vw);margin:0 auto}
-
-    /* Header */
-    header{
-      position:sticky; top:0; z-index:50;
-      background:#ffffffcc; backdrop-filter:blur(8px);
-      border-bottom:1px solid var(--border);
-    }
-    .nav{
-      display:flex; align-items:center; justify-content:space-between;
-      gap:24px; padding:10px 0;
-    }
-
-    /* Marca / logo */
-    .brand{ display:flex; align-items:center; }
-    .brand img{
-      height:60px;       /* altura padronizada */
-      display:block;     /* evita “respiro” de inline img */
-      filter:none;       
-      margin:0;
-    }
-    /* Se a imagem tiver bordinha no PNG e parecer fora do alinhamento:
-       .brand img{ margin-left:-6px; } */
-
-    /* Menu */
-    nav ul{ list-style:none; display:flex; gap:18px; margin:0; padding:0; align-items:center; }
-    nav a{ padding:10px 12px; border-radius:12px; transition:background .2s; }
-    nav a:hover{ background:#0000000f; }
-
-    /* Conteúdo */
-    main{padding:28px 0}
-    .card{
-      background:#fff;border:1px solid var(--border);border-radius:20px;
-      box-shadow:var(--shadow);padding:24px;text-align:center;position:relative;overflow:hidden
-    }
-    .title{font-size:clamp(26px,4vw,34px);color:var(--primary);margin:6px 0 8px}
-    .lead{color:var(--muted);margin:0 auto 18px;max-width:56ch}
-    .btn{padding:12px 18px;border-radius:12px;border:1px solid var(--border);background:#fff;font-weight:700}
-    .btn.primary{background:var(--primary);color:#fff}
-    .confetti{
-      position:absolute;inset:0;pointer-events:none;opacity:.08;background:
-      radial-gradient(6px 6px at 20% 30%, var(--accent), transparent 60%),
-      radial-gradient(6px 6px at 70% 25%, var(--primary), transparent 60%),
-      radial-gradient(6px 6px at 85% 70%, var(--accent), transparent 60%),
-      radial-gradient(6px 6px at 30% 75%, var(--primary), transparent 60%);filter:blur(.2px)
-    }
-
-    /* Acessibilidade (texto apenas para leitores de tela) */
-    .sr-only{
-      position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;
-      clip:rect(0,0,0,0);white-space:nowrap;border:0
-    }
-
-    /* Footer */
-    footer{margin-top:28px;border-top:1px solid var(--border);background:#fff}
-    .footer-top{border-bottom:1px solid var(--border);padding:18px 0}
-    .footer-grid{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:16px}
-    .footer-col h5{margin:0 0 8px;color:var(--primary);font-size:14px}
-    .footer-col a{display:block;padding:4px 0;color:var(--muted)}
-    .footer-bottom{padding:14px 0;color:var(--muted);font-size:14px;display:flex;justify-content:space-between;gap:12px;flex-wrap:wrap}
-    @media (max-width:900px){ .footer-grid{grid-template-columns:1fr 1fr} }
-    @media (max-width:600px){ .footer-grid{grid-template-columns:1fr} }
-  </style>
+  <link rel="stylesheet" href="/assets/main.css">
 </head>
-<body>
+<body class="obrigado">
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">

--- a/politicas.html
+++ b/politicas.html
@@ -31,66 +31,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/remixicon/fonts/remixicon.css" rel="stylesheet">
-
-  <style>
-    :root{
-      --primary:#0A2342; --bg:#F9FAFB; --ink:#1C1C1C; --muted:#6B7280;
-      --accent:#D4AF37; --border:#E5E7EB; --maxw:900px; --shadow:0 18px 48px rgba(0,0,0,.12)
-    }
-    *{box-sizing:border-box}
-    body{margin:0;font-family:'Inter',ui-sans-serif,system-ui;background:var(--bg);color:var(--ink);line-height:1.6}
-    a{text-decoration:none;color:inherit}
-    .container{width:min(var(--maxw),92vw);margin:0 auto}
-
-    /* Header */
-    header{
-      position:sticky; top:0; z-index:50;
-      background:#ffffffcc; backdrop-filter:blur(8px);
-      border-bottom:1px solid var(--border);
-    }
-    .nav{
-      display:flex; align-items:center; justify-content:space-between;
-      gap:24px; padding:10px 0;
-    }
-
-    /* Marca / logo */
-    .brand{ display:flex; align-items:center; }
-    .brand img{
-      height:60px;       /* altura padronizada */
-      display:block;     /* remove respiro de inline img */
-      filter:none;       /* sem sombra */
-      margin:0;
-    }
-    /* Se a imagem tiver bordinha dentro do PNG:
-    .brand img{ margin-left:-6px; }
-    */
-
-    /* Menu */
-    nav ul{ list-style:none; display:flex; gap:18px; margin:0; padding:0; align-items:center; }
-    nav a{ padding:10px 12px; border-radius:12px; transition:background .2s; }
-    nav a:hover{ background:#0000000f; }
-
-    /* Conteúdo */
-    main{padding:28px 0}
-    .card{background:#fff;border:1px solid var(--border);border-radius:20px;box-shadow:var(--shadow);padding:22px}
-    h1{color:var(--primary);margin:8px 0 6px}
-    h2{margin:10px 0 6px;color:var(--primary);font-size:20px;display:flex;gap:8px;align-items:center}
-    .muted{color:var(--muted)}
-    ul{margin:8px 0 0;padding-left:18px;color:var(--muted)}
-    .card + .card{margin-top:18px}
-
-    /* Footer */
-    footer{margin-top:28px;border-top:1px solid var(--border);background:#fff}
-    .footer-top{border-bottom:1px solid var(--border);padding:18px 0}
-    .footer-grid{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:16px}
-    .footer-col h5{margin:0 0 8px;color:var(--primary);font-size:14px}
-    .footer-col a{display:block;padding:4px 0;color:var(--muted)}
-    .footer-bottom{padding:14px 0;color:var(--muted);font-size:14px;display:flex;justify-content:space-between;gap:12px;flex-wrap:wrap}
-    @media (max-width:900px){ .footer-grid{grid-template-columns:1fr 1fr} }
-    @media (max-width:600px){ .footer-grid{grid-template-columns:1fr} }
-  </style>
+  <link rel="stylesheet" href="/assets/main.css">
 </head>
-<body>
+<body class="politicas">
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">


### PR DESCRIPTION
## Summary
- consolidate inline CSS into `assets/main.css`
- extract homepage JavaScript to `assets/main.js`
- update pages to reference shared assets

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e3101bb48330a9713459b49459f0