### PR TITLE
Ajusta logo e navegação responsiva

### DIFF
--- a/assets/contato.css
+++ b/assets/contato.css
@@ -5,6 +5,7 @@
     *{box-sizing:border-box}
     body{margin:0;font-family:'Inter',ui-sans-serif,system-ui;background:var(--bg);color:var(--ink);line-height:1.6}
     a{text-decoration:none;color:inherit}
+    a:visited{color:inherit}
     .container{width:min(var(--maxw),92vw);margin:0 auto}
 
     /* Header */
@@ -20,7 +21,7 @@
     /* Marca / logo */
     .brand{ display:flex; align-items:center; }
     .brand img{
-      height:80px;
+      height:clamp(64px,14vw,96px);
       display:block;
       filter:none;
       margin:0;
@@ -29,6 +30,11 @@
     nav ul{ list-style:none; display:flex; gap:18px; margin:0; padding:0; align-items:center; }
     nav a{ padding:10px 12px; border-radius:12px; transition:background .2s; }
     nav a:hover{ background:#0000000f; }
+    @media (max-width:720px){
+      .nav{flex-direction:column;align-items:flex-start;gap:12px}
+      nav ul{flex-wrap:wrap;gap:12px;justify-content:flex-start}
+      nav a{padding:8px 10px}
+    }
 
     /* Conteúdo */
     main{padding:28px 0}

--- a/assets/index.css
+++ b/assets/index.css
@@ -7,6 +7,7 @@
     body{margin:0;font-family:'Inter',ui-sans-serif,system-ui;background:var(--bg);color:var(--ink);line-height:1.6}
     img{max-width:100%;display:block}
     a{color:inherit;text-decoration:none}
+    a:visited{color:inherit}
     .container{width:min(var(--maxw),92vw);margin:0 auto}
 
     /* Header */
@@ -23,7 +24,7 @@ header{
     /* Marca / logo */
     .brand{ display:flex; align-items:center; }
     .brand img{
-      height:80px;       /* logo maior */
+      height:clamp(64px,14vw,96px); /* logo responsiva e maior */
       display:block;     /* evita “respiro” de inline img */
       filter:none;       /* <= remove sombra */
       margin:0;          /* zera offsets */
@@ -35,6 +36,11 @@ header{
     nav ul{ list-style:none; display:flex; gap:18px; margin:0; padding:0; align-items:center; }
     nav a{ padding:10px 12px; border-radius:12px; transition:background .2s; }
     nav a:hover{ background:#0000000f; }
+    @media (max-width:720px){
+      .nav{flex-direction:column;align-items:flex-start;gap:12px}
+      nav ul{flex-wrap:wrap;gap:12px;justify-content:flex-start}
+      nav a{padding:8px 10px}
+    }
 
     /* Hero */
     .hero{position:relative;min-height:100svh;display:grid;place-items:center;padding:88px 0}

--- a/assets/main.css
+++ b/assets/main.css
@@ -7,6 +7,7 @@
 body{margin:0;font-family:'Inter',ui-sans-serif,system-ui;background:var(--bg);color:var(--ink);line-height:1.6}
 img{max-width:100%;display:block}
 a{color:inherit;text-decoration:none}
+a:visited{color:inherit}
 .container{width:min(var(--maxw),92vw);margin:0 auto}
 
 /* Header */
@@ -23,7 +24,7 @@ header{
 /* Marca / logo */
 .brand{ display:flex; align-items:center; }
 .brand img{
-  height:80px;       /* logo maior */
+  height:clamp(64px,14vw,96px); /* logo responsiva e maior */
   display:block;     /* evita “respiro” de inline img */
   filter:none;       /* <= remove sombra */
   margin:0;          /* zera offsets */
@@ -35,6 +36,11 @@ header{
 nav ul{ list-style:none; display:flex; gap:18px; margin:0; padding:0; align-items:center; }
 nav a{ padding:10px 12px; border-radius:12px; transition:background .2s; }
 nav a:hover{ background:#0000000f; }
+@media (max-width:720px){
+  .nav{flex-direction:column;align-items:flex-start;gap:12px}
+  nav ul{flex-wrap:wrap;gap:12px;justify-content:flex-start}
+  nav a{padding:8px 10px}
+}
 
 /* Hero */
 .hero{position:relative;min-height:100svh;display:grid;place-items:center;padding:88px 0}

--- a/assets/obrigado.css
+++ b/assets/obrigado.css
@@ -2,6 +2,7 @@
     *{box-sizing:border-box}
     body{margin:0;font-family:'Inter',ui-sans-serif,system-ui;background:var(--bg);color:var(--ink);line-height:1.6}
     a{text-decoration:none;color:inherit}
+    a:visited{color:inherit}
     .container{width:min(var(--maxw),92vw);margin:0 auto}
 
     /* Header */
@@ -18,9 +19,9 @@
     /* Marca / logo */
     .brand{ display:flex; align-items:center; }
     .brand img{
-      height:80px;       /* logo maior */
+      height:clamp(64px,14vw,96px);       /* logo responsiva e maior */
       display:block;     /* evita “respiro” de inline img */
-      filter:none;       
+      filter:none;
       margin:0;
     }
     /* Se a imagem tiver bordinha no PNG e parecer fora do alinhamento:
@@ -30,6 +31,11 @@
     nav ul{ list-style:none; display:flex; gap:18px; margin:0; padding:0; align-items:center; }
     nav a{ padding:10px 12px; border-radius:12px; transition:background .2s; }
     nav a:hover{ background:#0000000f; }
+    @media (max-width:720px){
+      .nav{flex-direction:column;align-items:flex-start;gap:12px}
+      nav ul{flex-wrap:wrap;gap:12px;justify-content:flex-start}
+      nav a{padding:8px 10px}
+    }
 
     /* Conteúdo */
     main{padding:28px 0}

--- a/assets/politicas.css
+++ b/assets/politicas.css
@@ -5,6 +5,7 @@
     *{box-sizing:border-box}
     body{margin:0;font-family:'Inter',ui-sans-serif,system-ui;background:var(--bg);color:var(--ink);line-height:1.6}
     a{text-decoration:none;color:inherit}
+    a:visited{color:inherit}
     .container{width:min(var(--maxw),92vw);margin:0 auto}
 
     /* Header */
@@ -21,7 +22,7 @@
     /* Marca / logo */
     .brand{ display:flex; align-items:center; }
     .brand img{
-      height:80px;       /* logo maior */
+      height:clamp(64px,14vw,96px); /* logo responsiva maior */
       display:block;     /* remove respiro de inline img */
       filter:none;       /* sem sombra */
       margin:0;
@@ -34,6 +35,11 @@
     nav ul{ list-style:none; display:flex; gap:18px; margin:0; padding:0; align-items:center; }
     nav a{ padding:10px 12px; border-radius:12px; transition:background .2s; }
     nav a:hover{ background:#0000000f; }
+    @media (max-width:720px){
+      .nav{flex-direction:column;align-items:flex-start;gap:12px}
+      nav ul{flex-wrap:wrap;gap:12px;justify-content:flex-start}
+      nav a{padding:8px 10px}
+    }
 
     /* Conteúdo */
     main{padding:28px 0}


### PR DESCRIPTION
## Summary
- aumenta a logo com altura responsiva via clamp, mantendo consistência em todas as páginas
- garante que os links preservem a mesma cor, mesmo em estado visitado
- ajusta o menu para empilhar no mobile, evitando que quebre em telas estreitas

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c989d98f548330b8646f74845662f0