### PR TITLE
Ajusta dimensões da marca e animações da home

### DIFF
--- a/assets/contato.css
+++ b/assets/contato.css
@@ -21,14 +21,15 @@
     /* Marca / logo */
     .brand{ display:flex; align-items:center; }
     .brand img{
-      height:clamp(64px,14vw,96px);
+      height:clamp(80px,20vw,140px);
       display:block;
       filter:none;
       margin:0;
     }
     /* Menu */
     nav ul{ list-style:none; display:flex; gap:18px; margin:0; padding:0; align-items:center; }
-    nav a{ padding:10px 12px; border-radius:12px; transition:background .2s; }
+    nav a{ padding:10px 12px; border-radius:12px; transition:background .2s; color:var(--ink); }
+    nav a:visited{ color:var(--ink); }
     nav a:hover{ background:#0000000f; }
     @media (max-width:720px){
       .nav{flex-direction:column;align-items:flex-start;gap:12px}
@@ -60,4 +61,4 @@
     .footer-col a{display:block;padding:4px 0;color:var(--muted)}
     .footer-bottom{padding:14px 0;color:var(--muted);font-size:14px;display:flex;justify-content:space-between;gap:12px;flex-wrap:wrap}
     @media (max-width:900px){ .footer-grid{grid-template-columns:1fr 1fr} }
-    @media (max-width:600px){ .footer-grid{grid-template-columns:1fr} }
+    @media (max-width:600px){ .footer-grid{grid-template-columns:1fr} .footer-bottom{flex-direction:column;align-items:flex-start;gap:8px} }

--- a/assets/index.css
+++ b/assets/index.css
@@ -24,7 +24,7 @@ header{
     /* Marca / logo */
     .brand{ display:flex; align-items:center; }
     .brand img{
-      height:clamp(64px,14vw,96px); /* logo responsiva e maior */
+      height:clamp(80px,20vw,140px); /* logo responsiva maior */
       display:block;     /* evita “respiro” de inline img */
       filter:none;       /* <= remove sombra */
       margin:0;          /* zera offsets */
@@ -34,7 +34,8 @@ header{
     
     /* Menu */
     nav ul{ list-style:none; display:flex; gap:18px; margin:0; padding:0; align-items:center; }
-    nav a{ padding:10px 12px; border-radius:12px; transition:background .2s; }
+    nav a{ padding:10px 12px; border-radius:12px; transition:background .2s; color:var(--ink); }
+    nav a:visited{ color:var(--ink); }
     nav a:hover{ background:#0000000f; }
     @media (max-width:720px){
       .nav{flex-direction:column;align-items:flex-start;gap:12px}
@@ -109,6 +110,8 @@ header{
     .footer-col h5{margin:0 0 8px;color:var(--primary);font-size:14px}
     .footer-col a{display:block;padding:4px 0;color:var(--muted)}
     .footer-bottom{padding:14px 0;color:var(--muted);font-size:14px;display:flex;justify-content:space-between;gap:12px;flex-wrap:wrap}
+    @media (max-width:900px){ .footer-grid{grid-template-columns:1fr 1fr} }
+    @media (max-width:600px){ .footer-grid{grid-template-columns:1fr} .footer-bottom{flex-direction:column;align-items:flex-start;gap:8px} }
 
     /* Animações suaves */
     .reveal{opacity:1;transform:none}

--- a/assets/main.css
+++ b/assets/main.css
@@ -24,7 +24,7 @@ header{
 /* Marca / logo */
 .brand{ display:flex; align-items:center; }
 .brand img{
-  height:clamp(64px,14vw,96px); /* logo responsiva e maior */
+  height:clamp(80px,20vw,140px); /* logo responsiva maior */
   display:block;     /* evita “respiro” de inline img */
   filter:none;       /* <= remove sombra */
   margin:0;          /* zera offsets */
@@ -34,7 +34,8 @@ header{
 
 /* Menu */
 nav ul{ list-style:none; display:flex; gap:18px; margin:0; padding:0; align-items:center; }
-nav a{ padding:10px 12px; border-radius:12px; transition:background .2s; }
+nav a{ padding:10px 12px; border-radius:12px; transition:background .2s; color:var(--ink); }
+nav a:visited{ color:var(--ink); }
 nav a:hover{ background:#0000000f; }
 @media (max-width:720px){
   .nav{flex-direction:column;align-items:flex-start;gap:12px}
@@ -110,7 +111,7 @@ footer{margin-top:10px;border-top:1px solid var(--border);background:#fff}
 .footer-col a{display:block;padding:4px 0;color:var(--muted)}
 .footer-bottom{padding:14px 0;color:var(--muted);font-size:14px;display:flex;justify-content:space-between;gap:12px;flex-wrap:wrap}
 @media (max-width:900px){ .footer-grid{grid-template-columns:1fr 1fr} }
-@media (max-width:600px){ .footer-grid{grid-template-columns:1fr} }
+@media (max-width:600px){ .footer-grid{grid-template-columns:1fr} .footer-bottom{flex-direction:column;align-items:flex-start;gap:8px} }
 
 /* Animações suaves */
 .reveal{opacity:1;transform:none}

--- a/assets/main.js
+++ b/assets/main.js
@@ -9,12 +9,25 @@ document.addEventListener('click',e=>{
   }
 });
 
-const io=new IntersectionObserver(entries=>{
-  entries.forEach(en=>{if(en.isIntersecting) en.target.classList.add('show');});
+const io=new IntersectionObserver((entries,observer)=>{
+  entries.forEach(en=>{
+    if(!en.isIntersecting) return;
+    en.target.classList.add('show');
+    observer.unobserve(en.target);
+  });
 },{threshold:.12});
 document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
 
+const finishLoad=img=>{
+  const apply=()=>requestAnimationFrame(()=>img.classList.add('loaded'));
+  if('decode' in img){img.decode().catch(()=>{}).then(apply);} else{apply();}
+};
+
 document.querySelectorAll('img.fade-img').forEach(img=>{
-  if(img.complete){img.classList.add('loaded');}
-  else{img.addEventListener('load',()=>img.classList.add('loaded'));}
+  if(img.complete){
+    if(img.naturalWidth>0){finishLoad(img);} else{img.classList.add('loaded');}
+    return;
+  }
+  img.addEventListener('load',()=>finishLoad(img),{once:true});
+  img.addEventListener('error',()=>img.classList.add('loaded'),{once:true});
 });

--- a/assets/obrigado.css
+++ b/assets/obrigado.css
@@ -19,7 +19,7 @@
     /* Marca / logo */
     .brand{ display:flex; align-items:center; }
     .brand img{
-      height:clamp(64px,14vw,96px);       /* logo responsiva e maior */
+      height:clamp(80px,20vw,140px);       /* logo responsiva maior */
       display:block;     /* evita “respiro” de inline img */
       filter:none;
       margin:0;
@@ -29,7 +29,8 @@
 
     /* Menu */
     nav ul{ list-style:none; display:flex; gap:18px; margin:0; padding:0; align-items:center; }
-    nav a{ padding:10px 12px; border-radius:12px; transition:background .2s; }
+    nav a{ padding:10px 12px; border-radius:12px; transition:background .2s; color:var(--ink); }
+    nav a:visited{ color:var(--ink); }
     nav a:hover{ background:#0000000f; }
     @media (max-width:720px){
       .nav{flex-direction:column;align-items:flex-start;gap:12px}
@@ -69,4 +70,4 @@
     .footer-col a{display:block;padding:4px 0;color:var(--muted)}
     .footer-bottom{padding:14px 0;color:var(--muted);font-size:14px;display:flex;justify-content:space-between;gap:12px;flex-wrap:wrap}
     @media (max-width:900px){ .footer-grid{grid-template-columns:1fr 1fr} }
-    @media (max-width:600px){ .footer-grid{grid-template-columns:1fr} }
+    @media (max-width:600px){ .footer-grid{grid-template-columns:1fr} .footer-bottom{flex-direction:column;align-items:flex-start;gap:8px} }

--- a/assets/politicas.css
+++ b/assets/politicas.css
@@ -22,7 +22,7 @@
     /* Marca / logo */
     .brand{ display:flex; align-items:center; }
     .brand img{
-      height:clamp(64px,14vw,96px); /* logo responsiva maior */
+      height:clamp(80px,20vw,140px); /* logo responsiva maior */
       display:block;     /* remove respiro de inline img */
       filter:none;       /* sem sombra */
       margin:0;
@@ -33,7 +33,8 @@
 
     /* Menu */
     nav ul{ list-style:none; display:flex; gap:18px; margin:0; padding:0; align-items:center; }
-    nav a{ padding:10px 12px; border-radius:12px; transition:background .2s; }
+    nav a{ padding:10px 12px; border-radius:12px; transition:background .2s; color:var(--ink); }
+    nav a:visited{ color:var(--ink); }
     nav a:hover{ background:#0000000f; }
     @media (max-width:720px){
       .nav{flex-direction:column;align-items:flex-start;gap:12px}
@@ -58,4 +59,4 @@
     .footer-col a{display:block;padding:4px 0;color:var(--muted)}
     .footer-bottom{padding:14px 0;color:var(--muted);font-size:14px;display:flex;justify-content:space-between;gap:12px;flex-wrap:wrap}
     @media (max-width:900px){ .footer-grid{grid-template-columns:1fr 1fr} }
-    @media (max-width:600px){ .footer-grid{grid-template-columns:1fr} }
+    @media (max-width:600px){ .footer-grid{grid-template-columns:1fr} .footer-bottom{flex-direction:column;align-items:flex-start;gap:8px} }


### PR DESCRIPTION
## Summary
- aumenta a logo nas páginas principais e aplica a mesma cor aos links de navegação
- padroniza o rodapé para colunas verticais no mobile, igualando a home às demais páginas
- torna a animação das imagens de serviços mais estável usando decode/requestAnimationFrame

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c9d3cd2a308330a2501f102fcd75c8