### PR TITLE
Improve favicon support and align home visuals

### DIFF
--- a/assets/contato.css
+++ b/assets/contato.css
@@ -56,10 +56,11 @@
     .meta{display:flex;gap:16px;flex-wrap:wrap;color:var(--muted);font-size:14px;margin-top:10px}
 
     /* Footer */
-    footer{margin-top:28px;border-top:1px solid var(--border);background:#fff}
+    footer{margin-top:10px;border-top:1px solid var(--border);background:#fff}
     .footer-top{border-bottom:1px solid var(--border);padding:18px 0}
     .footer-grid{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:16px}
     .footer-col h5{margin:0 0 8px;color:var(--primary);font-size:14px}
+    .footer-col p{margin:0;color:var(--muted)}
     .footer-col a{display:block;padding:4px 0;color:var(--muted)}
     .footer-bottom{padding:14px 0;color:var(--muted);font-size:14px;display:flex;justify-content:space-between;gap:12px;flex-wrap:wrap}
     @media (max-width:900px){ .footer-grid{grid-template-columns:1fr 1fr} }

--- a/assets/index.css
+++ b/assets/index.css
@@ -54,7 +54,8 @@ header{
     .hero-card{width:min(var(--maxw),92vw);display:grid;grid-template-columns:1.15fr .85fr;gap:clamp(16px,3.6vw,32px);
       background:linear-gradient(140deg,#fff 0%,#f7f7f8 100%);border-radius:var(--r-lg);
       border:1px solid var(--border);
-      box-shadow:0 32px 84px rgba(17,24,39,.14);padding:clamp(22px,4vw,40px);color:var(--ink);position:relative}
+      box-shadow:0 32px 84px rgba(17,24,39,.14);padding:clamp(22px,4vw,40px);color:var(--ink);position:relative;
+      align-items:stretch}
     .hero-card::after{content:"";position:absolute;inset:0;border-radius:inherit;background:radial-gradient(820px 520px at 0% 0%,rgba(255,255,255,.6),transparent 70%);opacity:.55;pointer-events:none}
     .hero-card > *{position:relative;z-index:1}
     .hero-card > div:first-child{display:grid;gap:12px}
@@ -64,12 +65,13 @@ header{
     .btn{display:inline-flex;align-items:center;gap:10px;padding:12px 18px;border-radius:12px;font-weight:700;cursor:pointer;border:1px solid var(--border);background:#fff}
     .btn.primary{background:var(--primary);color:#fff;box-shadow:0 6px 18px rgba(10,35,66,.20)}
     .btn.primary:hover{transform:translateY(-1px) scale(1.01);box-shadow:0 10px 28px rgba(10,35,66,.28)}
-    .hero-photo{border-radius:18px;overflow:hidden;border:1px solid rgba(255,255,255,.32);aspect-ratio:4/3;box-shadow:0 26px 60px rgba(7,24,46,.36)}
-    .hero-photo img{width:100%;height:100%;object-fit:cover}
+    .hero-photo{border-radius:18px;overflow:hidden;border:1px solid rgba(255,255,255,.32);aspect-ratio:4/3;box-shadow:0 26px 60px rgba(7,24,46,.36);height:100%;min-height:280px}
+    .hero-photo img{width:100%;height:100%;object-fit:cover;object-position:center}
     .hero-card .kicker{color:var(--muted)}
     .hero-card .hero-title{color:var(--ink)}
     .hero-card .hero-sub{color:var(--muted)}
     .hero-card .hero-sub strong{color:var(--ink)}
+    .hero-card .btn{padding:10px 16px;font-size:.95rem}
     .hero-card .btn.primary{
       background:var(--primary);
       color:#fff;
@@ -160,11 +162,11 @@ header{
     .section-dark .step h4 i{color:var(--accent)}
 
     .cta-section{background:var(--bg)}
-    .cta-section .cta-card{background:linear-gradient(140deg,var(--primary) 0%,#133156 100%);color:#fff;border:0;box-shadow:0 32px 70px rgba(10,35,66,.28)}
-    .cta-section .section-title{color:#fff}
-    .cta-section .section-sub{color:var(--muted-on-dark)}
-    .cta-section .btn.primary{background:var(--accent);color:#fff;box-shadow:0 12px 30px rgba(212,175,55,.38);border:0}
-    .cta-section .btn.primary:hover{box-shadow:0 18px 40px rgba(212,175,55,.5)}
+    .cta-section .cta-card{background:#fff;color:var(--ink);border:1px solid var(--border);box-shadow:0 24px 60px rgba(17,24,39,.12)}
+    .cta-section .section-title{color:var(--primary)}
+    .cta-section .section-sub{color:var(--muted)}
+    .cta-section .btn.primary{background:var(--primary);color:#fff;box-shadow:0 12px 30px rgba(10,35,66,.24);border:0}
+    .cta-section .btn.primary:hover{box-shadow:0 18px 40px rgba(10,35,66,.32)}
 
     .card:hover,
     .service:hover,

--- a/assets/main.css
+++ b/assets/main.css
@@ -110,6 +110,7 @@ footer{margin-top:10px;border-top:1px solid var(--border);background:#fff}
 .footer-top{border-bottom:1px solid var(--border);padding:18px 0}
 .footer-grid{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:16px}
 .footer-col h5{margin:0 0 8px;color:var(--primary);font-size:14px}
+.footer-col p{margin:0;color:var(--muted)}
 .footer-col a{display:block;padding:4px 0;color:var(--muted)}
 .footer-bottom{padding:14px 0;color:var(--muted);font-size:14px;display:flex;justify-content:space-between;gap:12px;flex-wrap:wrap}
 @media (max-width:900px){ .footer-grid{grid-template-columns:1fr 1fr} }
@@ -164,4 +165,4 @@ body.obrigado .sr-only{position:absolute!important;width:1px;height:1px;padding:
 
 body.contato footer,
 body.obrigado footer,
-body.politicas footer{margin-top:28px}
+body.politicas footer{margin-top:10px}

--- a/assets/obrigado.css
+++ b/assets/obrigado.css
@@ -65,10 +65,11 @@
     }
 
     /* Footer */
-    footer{margin-top:28px;border-top:1px solid var(--border);background:#fff}
+    footer{margin-top:10px;border-top:1px solid var(--border);background:#fff}
     .footer-top{border-bottom:1px solid var(--border);padding:18px 0}
     .footer-grid{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:16px}
     .footer-col h5{margin:0 0 8px;color:var(--primary);font-size:14px}
+    .footer-col p{margin:0;color:var(--muted)}
     .footer-col a{display:block;padding:4px 0;color:var(--muted)}
     .footer-bottom{padding:14px 0;color:var(--muted);font-size:14px;display:flex;justify-content:space-between;gap:12px;flex-wrap:wrap}
     @media (max-width:900px){ .footer-grid{grid-template-columns:1fr 1fr} }

--- a/assets/politicas.css
+++ b/assets/politicas.css
@@ -54,10 +54,11 @@
     .card + .card{margin-top:18px}
 
     /* Footer */
-    footer{margin-top:28px;border-top:1px solid var(--border);background:#fff}
+    footer{margin-top:10px;border-top:1px solid var(--border);background:#fff}
     .footer-top{border-bottom:1px solid var(--border);padding:18px 0}
     .footer-grid{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:16px}
     .footer-col h5{margin:0 0 8px;color:var(--primary);font-size:14px}
+    .footer-col p{margin:0;color:var(--muted)}
     .footer-col a{display:block;padding:4px 0;color:var(--muted)}
     .footer-bottom{padding:14px 0;color:var(--muted);font-size:14px;display:flex;justify-content:space-between;gap:12px;flex-wrap:wrap}
     @media (max-width:900px){ .footer-grid{grid-template-columns:1fr 1fr} }

--- a/blog/como-ia-transforma-processos.html
+++ b/blog/como-ia-transforma-processos.html
@@ -16,6 +16,9 @@
   <link rel="apple-touch-icon" href="/apple-touch-icon.png">
   <link rel="manifest" href="/site.webmanifest">
   <meta name="theme-color" content="#0A2342">
+  <meta name="msapplication-TileColor" content="#0A2342">
+  <meta name="msapplication-TileImage" content="/android-chrome-192x192.png">
+  <meta name="msapplication-config" content="/browserconfig.xml">
 
   <!-- Open Graph -->
   <meta property="og:title" content="Como a IA transforma processos sem virar burocracia — Munnius" />

--- a/blog/index.html
+++ b/blog/index.html
@@ -16,6 +16,9 @@
   <link rel="apple-touch-icon" href="/apple-touch-icon.png">
   <link rel="manifest" href="/site.webmanifest">
   <meta name="theme-color" content="#0A2342">
+  <meta name="msapplication-TileColor" content="#0A2342">
+  <meta name="msapplication-TileImage" content="/android-chrome-192x192.png">
+  <meta name="msapplication-config" content="/browserconfig.xml">
 
   <!-- Open Graph -->
   <meta property="og:title" content="Blog Munnius — Processos claros, IA aplicada e projetos que andam" />

--- a/blog/operacao-em-90-dias.html
+++ b/blog/operacao-em-90-dias.html
@@ -16,6 +16,9 @@
   <link rel="apple-touch-icon" href="/apple-touch-icon.png">
   <link rel="manifest" href="/site.webmanifest">
   <meta name="theme-color" content="#0A2342">
+  <meta name="msapplication-TileColor" content="#0A2342">
+  <meta name="msapplication-TileImage" content="/android-chrome-192x192.png">
+  <meta name="msapplication-config" content="/browserconfig.xml">
 
   <!-- Open Graph -->
   <meta property="og:title" content="Plano em 90 dias para organizar sua operação — Munnius" />

--- a/blog/playbook-atendimento-ia.html
+++ b/blog/playbook-atendimento-ia.html
@@ -16,6 +16,9 @@
   <link rel="apple-touch-icon" href="/apple-touch-icon.png">
   <link rel="manifest" href="/site.webmanifest">
   <meta name="theme-color" content="#0A2342">
+  <meta name="msapplication-TileColor" content="#0A2342">
+  <meta name="msapplication-TileImage" content="/android-chrome-192x192.png">
+  <meta name="msapplication-config" content="/browserconfig.xml">
 
   <!-- Open Graph -->
   <meta property="og:title" content="Playbook de atendimento com IA para pequenas equipes — Munnius" />

--- a/browserconfig.xml
+++ b/browserconfig.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<browserconfig>
+  <msapplication>
+    <tile>
+      <square150x150logo src="/android-chrome-192x192.png" />
+      <TileColor>#0A2342</TileColor>
+    </tile>
+  </msapplication>
+</browserconfig>

--- a/contato.html
+++ b/contato.html
@@ -16,6 +16,9 @@
   <link rel="apple-touch-icon" href="/apple-touch-icon.png">
   <link rel="manifest" href="/site.webmanifest">
   <meta name="theme-color" content="#0A2342">
+  <meta name="msapplication-TileColor" content="#0A2342">
+  <meta name="msapplication-TileImage" content="/android-chrome-192x192.png">
+  <meta name="msapplication-config" content="/browserconfig.xml">
 
   <!-- Open Graph -->
   <meta property="og:title" content="Contato — Munnius" />

--- a/index.html
+++ b/index.html
@@ -16,6 +16,10 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png">
   <link rel="manifest" href="/site.webmanifest">
+  <meta name="theme-color" content="#0A2342">
+  <meta name="msapplication-TileColor" content="#0A2342">
+  <meta name="msapplication-TileImage" content="/android-chrome-192x192.png">
+  <meta name="msapplication-config" content="/browserconfig.xml">
 
   <!-- Open Graph -->
   <meta property="og:title" content="Munnius — Processos claros, IA aplicada e projetos que andam">

--- a/obrigado.html
+++ b/obrigado.html
@@ -16,6 +16,9 @@
   <link rel="apple-touch-icon" href="/apple-touch-icon.png">
   <link rel="manifest" href="/site.webmanifest">
   <meta name="theme-color" content="#0A2342">
+  <meta name="msapplication-TileColor" content="#0A2342">
+  <meta name="msapplication-TileImage" content="/android-chrome-192x192.png">
+  <meta name="msapplication-config" content="/browserconfig.xml">
   <!-- Segurança -->
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https:; style-src 'self' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net; script-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'">
   <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
@@ -68,7 +71,7 @@
       <div class="container footer-grid">
         <div class="footer-col">
           <h5>Munnius</h5>
-          <p class="lead m0">Processos, IA aplicada e projetos internos.</p>
+          <p class="section-sub m0">Processos, IA aplicada e projetos internos.</p>
         </div>
         <div class="footer-col">
           <h5>Site</h5>

--- a/politicas.html
+++ b/politicas.html
@@ -16,6 +16,9 @@
   <link rel="apple-touch-icon" href="/apple-touch-icon.png">
   <link rel="manifest" href="/site.webmanifest">
   <meta name="theme-color" content="#0A2342">
+  <meta name="msapplication-TileColor" content="#0A2342">
+  <meta name="msapplication-TileImage" content="/android-chrome-192x192.png">
+  <meta name="msapplication-config" content="/browserconfig.xml">
 
   <!-- Open Graph -->
   <meta property="og:title" content="Políticas — Munnius" />


### PR DESCRIPTION
## Summary
- add Windows tile metadata on every page and ship a browserconfig.xml so Bing can pick up the favicon
- tweak the home hero to keep the photo covering the card, reduce the CTA size and restyle the closing CTA to match the brand palette
- align footer spacing and text styling across all pages for a consistent finish

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d48ec252288330a52077956e7066dc