### PR TITLE
Refresh header branding, standardize CTAs and add subtle motion

### DIFF
--- a/assets/blog.css
+++ b/assets/blog.css
@@ -18,18 +18,20 @@ img{max-width:100%;display:block}
 a{text-decoration:none;color:inherit}
 a:visited{color:inherit}
 .container{width:min(var(--maxw),92vw);margin:0 auto}
+header .container{width:min(1180px,92vw)}
 
 header{position:sticky;top:0;z-index:140;background:rgba(244,241,236,.82);backdrop-filter:blur(16px);border-bottom:1px solid var(--border)}
 .nav{display:flex;align-items:center;justify-content:space-between;gap:24px;padding:12px 0}
 .brand{display:flex;align-items:center}
 .brand img{height:clamp(42px,10vw,74px);width:auto;display:block}
+.brand-text{font-size:clamp(20px,2.6vw,30px);font-weight:700;letter-spacing:.24em;text-transform:uppercase;color:var(--ink)}
 nav ul{list-style:none;display:flex;gap:16px;align-items:center;margin:0;padding:0;flex-wrap:wrap}
-nav a{padding:10px 14px;border-radius:999px;transition:background .2s ease;font-weight:500}
+nav a{padding:10px 14px;border-radius:999px;transition:background .2s ease;font-weight:500;color:var(--ink)}
 nav a:hover{background:rgba(24,32,34,.08)}
 .nav-cta{background:#1f5b59;color:#fff;border-radius:999px;padding:10px 18px;font-weight:600;border:1px solid #184645;box-shadow:0 10px 24px rgba(31,91,89,.28)}
 .nav-cta:hover{background:#184645}
 
-.btn{display:inline-flex;align-items:center;gap:10px;padding:12px 20px;border-radius:999px;border:1px solid var(--border);font-weight:600}
+.btn{display:inline-flex;align-items:center;gap:10px;padding:12px 20px;border-radius:999px;border:1px solid var(--border);font-weight:600;transition:transform .2s ease,box-shadow .2s ease}
 .btn.primary{background:var(--accent);color:#fff;border-color:transparent;box-shadow:0 16px 32px rgba(47,111,109,.22)}
 .btn.primary:hover{transform:translateY(-1px)}
 .btn.ghost{background:transparent;color:var(--accent)}
@@ -65,7 +67,7 @@ nav a:hover{background:rgba(24,32,34,.08)}
 .results-info{margin:0;font-size:14px;color:var(--muted)}
 
 .post-grid{display:grid;gap:20px;grid-template-columns:repeat(3,1fr);align-items:stretch}
-.post-card{background:#fff;border:1px solid var(--border);border-radius:20px;padding:20px;display:flex;flex-direction:column;gap:12px;height:100%;box-shadow:var(--shadow-soft);transition:transform .15s ease,box-shadow .15s ease}
+.post-card{background:#fff;border:1px solid var(--border);border-radius:20px;padding:20px;display:flex;flex-direction:column;gap:12px;height:100%;box-shadow:var(--shadow-soft);transition:transform .25s ease,box-shadow .25s ease}
 .post-card:hover{transform:translateY(-4px);box-shadow:var(--shadow)}
 .post-card h3{margin:0;font-size:18px}
 .post-card p{margin:0;color:var(--muted)}
@@ -81,14 +83,16 @@ nav a:hover{background:rgba(24,32,34,.08)}
 .breadcrumbs li+li::before{content:"/";color:rgba(24,32,34,.4)}
 .breadcrumbs a{color:var(--accent)}
 
-.post-hero{padding:48px;border-radius:var(--radius-lg);border:1px solid var(--border);background:#fff;box-shadow:var(--shadow);margin-bottom:32px}
+.post-hero{padding:48px;border-radius:var(--radius-lg);border:1px solid var(--border);background:#fff;box-shadow:var(--shadow);margin-bottom:32px;transition:transform .25s ease,box-shadow .25s ease}
+.post-hero:hover{transform:translateY(-3px);box-shadow:0 28px 70px rgba(15,23,30,.2)}
 .post-hero .kicker{text-transform:uppercase;letter-spacing:.18em;font-size:12px;color:var(--muted);margin:0 0 10px}
 .post-hero h1{margin:0 0 18px;font-size:clamp(30px,4vw,44px)}
 .post-hero .post-meta{display:flex;flex-wrap:wrap;gap:12px;font-size:14px;color:var(--muted)}
 .post-hero .post-meta time{padding:6px 14px;border-radius:999px;background:var(--accent-soft);color:var(--accent);font-weight:600}
 .post-hero .post-meta span{padding:6px 14px;border-radius:999px;border:1px solid var(--border);background:#fdfbf9;display:inline-flex;align-items:center;gap:8px}
 
-.post-content{background:#fff;border:1px solid var(--border);border-radius:var(--radius-lg);padding:32px;box-shadow:var(--shadow-soft);display:grid;gap:18px}
+.post-content{background:#fff;border:1px solid var(--border);border-radius:var(--radius-lg);padding:32px;box-shadow:var(--shadow-soft);display:grid;gap:18px;transition:transform .25s ease,box-shadow .25s ease}
+.post-content:hover{transform:translateY(-3px);box-shadow:0 24px 56px rgba(15,23,30,.18)}
 .post-content h2{margin:16px 0 6px;font-size:22px}
 .post-content p{margin:0;color:var(--muted)}
 .post-content ul{margin:0;padding-left:20px;color:var(--muted);display:grid;gap:8px}

--- a/assets/contato.css
+++ b/assets/contato.css
@@ -17,6 +17,7 @@ body{margin:0;font-family:'Manrope',system-ui,ui-sans-serif;background:var(--bg)
 a{text-decoration:none;color:inherit}
 a:visited{color:inherit}
 .container{width:min(var(--maxw),92vw);margin:0 auto}
+header .container{width:min(1180px,92vw)}
 
 header{
   position:sticky;top:0;z-index:140;background:rgba(244,241,236,.82);
@@ -25,8 +26,9 @@ header{
 .nav{display:flex;align-items:center;justify-content:space-between;gap:24px;padding:12px 0}
 .brand{display:flex;align-items:center}
 .brand img{height:clamp(42px,10vw,74px);width:auto;display:block}
+.brand-text{font-size:clamp(20px,2.6vw,30px);font-weight:700;letter-spacing:.24em;text-transform:uppercase;color:var(--ink)}
 nav ul{list-style:none;display:flex;gap:16px;align-items:center;margin:0;padding:0;flex-wrap:wrap}
-nav a{padding:10px 14px;border-radius:999px;transition:background .2s ease;font-weight:500}
+nav a{padding:10px 14px;border-radius:999px;transition:background .2s ease;font-weight:500;color:var(--ink)}
 nav a:hover{background:rgba(24,32,34,.08)}
 .nav-cta{background:#1f5b59;color:#fff;border-radius:999px;padding:10px 18px;font-weight:600;border:1px solid #184645;box-shadow:0 10px 24px rgba(31,91,89,.28)}
 .nav-cta:hover{background:#184645}
@@ -37,18 +39,20 @@ main{padding:72px 0 96px}
 .contact-info p{margin:0 0 20px;color:var(--muted)}
 .pill{display:inline-flex;align-items:center;gap:8px;background:var(--accent-soft);color:var(--accent);padding:6px 14px;border-radius:999px;font-weight:600;font-size:13px}
 .info-cards{display:grid;gap:14px}
-.info-cards div{background:#fff;border:1px solid var(--border);border-radius:var(--radius-md);padding:16px;box-shadow:var(--shadow-soft)}
+.info-cards div{background:#fff;border:1px solid var(--border);border-radius:var(--radius-md);padding:16px;box-shadow:var(--shadow-soft);transition:transform .25s ease,box-shadow .25s ease}
+.info-cards div:hover{transform:translateY(-3px);box-shadow:var(--shadow)}
 .info-cards h3{margin:0 0 6px;font-size:16px}
 .info-cards p{margin:0;color:var(--muted)}
 
-.contact-form{background:#fff;border:1px solid var(--border);border-radius:var(--radius-lg);padding:26px;box-shadow:var(--shadow)}
+.contact-form{background:#fff;border:1px solid var(--border);border-radius:var(--radius-lg);padding:26px;box-shadow:var(--shadow);transition:transform .25s ease,box-shadow .25s ease}
+.contact-form:hover{transform:translateY(-3px);box-shadow:0 28px 70px rgba(15,23,30,.2)}
 .contact-form h2{margin:0 0 8px;font-size:22px}
 .contact-form p{margin:0 0 18px;color:var(--muted)}
 form{display:grid;gap:14px}
 label{display:grid;gap:8px;font-weight:600;color:var(--ink)}
 input,textarea{padding:12px 14px;border-radius:14px;border:1px solid var(--border);background:#fdfbf9;font:inherit;color:var(--ink)}
 textarea{min-height:140px;resize:vertical}
-button{display:inline-flex;align-items:center;gap:10px;justify-content:center;padding:12px 18px;border-radius:999px;border:0;background:var(--accent);color:#fff;font-weight:600;cursor:pointer;box-shadow:0 14px 28px rgba(47,111,109,.24);transition:transform .15s ease,box-shadow .15s ease}
+button{display:inline-flex;align-items:center;gap:10px;justify-content:center;padding:12px 18px;border-radius:999px;border:0;background:var(--accent);color:#fff;font-weight:600;cursor:pointer;box-shadow:0 14px 28px rgba(47,111,109,.24);transition:transform .2s ease,box-shadow .2s ease}
 button:hover{transform:translateY(-1px);box-shadow:0 18px 36px rgba(47,111,109,.32)}
 .meta{margin-top:14px;font-size:14px;color:var(--muted);display:flex;align-items:center;gap:8px}
 

--- a/assets/index.css
+++ b/assets/index.css
@@ -37,6 +37,13 @@ header{
 }
 .brand{display:flex;align-items:center}
 .brand img{height:clamp(42px,10vw,74px);width:auto;display:block}
+.brand-text{
+  font-size:clamp(20px,2.6vw,30px);
+  font-weight:700;
+  letter-spacing:.24em;
+  text-transform:uppercase;
+  color:var(--ink);
+}
 nav ul{list-style:none;display:flex;gap:16px;align-items:center;margin:0;padding:0;flex-wrap:wrap}
 nav a{padding:10px 14px;border-radius:999px;transition:background .2s ease;color:var(--ink);font-weight:500}
 nav a:hover{background:rgba(24,32,34,.08)}
@@ -93,12 +100,14 @@ section{padding:var(--space) 0;scroll-margin-top:120px}
 .section-block h2{margin:10px 0 16px;font-size:clamp(26px,3vw,34px)}
 .section-block p{margin:0 0 16px;color:var(--muted)}
 
-.stats-card{background:#fff;border:1px solid var(--border);border-radius:var(--radius-lg);padding:26px;display:grid;gap:20px;box-shadow:var(--shadow-soft)}
+.stats-card{background:#fff;border:1px solid var(--border);border-radius:var(--radius-lg);padding:26px;display:grid;gap:20px;box-shadow:var(--shadow-soft);transition:transform .25s ease,box-shadow .25s ease}
+.stats-card:hover{transform:translateY(-4px);box-shadow:var(--shadow)}
 .stats-card strong{font-size:24px}
 .stats-card p{margin:0;color:var(--muted)}
 .stats-card .label{text-transform:uppercase;letter-spacing:.18em;font-size:11px;color:var(--muted)}
 
-.service-card{background:#fff;border:1px solid var(--border);border-radius:var(--radius-md);padding:22px;display:grid;gap:12px;box-shadow:var(--shadow-soft);height:100%}
+.service-card{background:#fff;border:1px solid var(--border);border-radius:var(--radius-md);padding:22px;display:grid;gap:12px;box-shadow:var(--shadow-soft);height:100%;transition:transform .25s ease,box-shadow .25s ease}
+.service-card:hover{transform:translateY(-4px);box-shadow:var(--shadow)}
 .service-card h3{margin:0;font-size:20px}
 .service-card p{margin:0;color:var(--muted)}
 .service-card ul{margin:0;padding-left:18px;color:var(--muted);display:grid;gap:6px}
@@ -106,24 +115,29 @@ section{padding:var(--space) 0;scroll-margin-top:120px}
 .service-media img{width:100%;height:100%;object-fit:cover}
 
 .steps{display:grid;grid-template-columns:repeat(2,1fr);gap:18px}
-.step{background:#fff;border:1px solid var(--border);border-radius:var(--radius-md);padding:20px;display:flex;gap:16px;align-items:flex-start;box-shadow:var(--shadow-soft)}
+.step{background:#fff;border:1px solid var(--border);border-radius:var(--radius-md);padding:20px;display:flex;gap:16px;align-items:flex-start;box-shadow:var(--shadow-soft);transition:transform .25s ease,box-shadow .25s ease}
+.step:hover{transform:translateY(-3px);box-shadow:var(--shadow)}
 .step span{display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;border-radius:14px;background:var(--accent-soft);color:var(--accent);font-weight:700}
 .step h3{margin:0 0 6px;font-size:18px}
 .step p{margin:0;color:var(--muted)}
 
 .result-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:18px}
-.result-card{background:#fff;border:1px solid var(--border);border-radius:18px;padding:20px;box-shadow:var(--shadow-soft)}
+.result-card{background:#fff;border:1px solid var(--border);border-radius:18px;padding:20px;box-shadow:var(--shadow-soft);transition:transform .25s ease,box-shadow .25s ease}
+.result-card:hover{transform:translateY(-3px);box-shadow:var(--shadow)}
 .result-card h3{margin:0 0 8px;font-size:22px;color:var(--accent)}
 .result-card p{margin:0;color:var(--muted)}
 
-.blog-grid .blog-card{background:#fff;border:1px solid var(--border);border-radius:var(--radius-md);padding:22px;box-shadow:var(--shadow-soft);height:100%}
+.blog-grid .blog-card{background:#fff;border:1px solid var(--border);border-radius:var(--radius-md);padding:22px;box-shadow:var(--shadow-soft);height:100%;transition:transform .25s ease,box-shadow .25s ease}
+.blog-grid .blog-card:hover{transform:translateY(-4px);box-shadow:var(--shadow)}
 .blog-card a{display:grid;gap:12px;height:100%}
 .blog-card h3{margin:0;font-size:20px}
 .blog-card p{margin:0;color:var(--muted)}
 .blog-card .post-meta{font-size:14px;color:var(--muted)}
 .blog-card .post-link{font-weight:600;color:var(--accent);display:inline-flex;align-items:center;gap:6px}
 
-.cta-card{background:var(--bg-alt);border:1px solid rgba(47,111,109,.2);border-radius:var(--radius-lg);padding:30px;display:flex;align-items:center;justify-content:space-between;gap:22px;box-shadow:0 24px 60px rgba(15,23,30,.18)}
+.cta-card{background:var(--bg-alt);border:1px solid rgba(47,111,109,.2);border-radius:var(--radius-lg);padding:30px;display:flex;align-items:center;justify-content:space-between;gap:22px;box-shadow:0 24px 60px rgba(15,23,30,.18);transition:transform .25s ease,box-shadow .25s ease}
+.cta-card:hover{transform:translateY(-3px);box-shadow:0 28px 70px rgba(15,23,30,.22)}
+.cta-card .btn.primary{white-space:nowrap;padding:14px 28px;font-size:16px}
 .cta-card .btn.primary{background:#1f5b59;box-shadow:0 16px 32px rgba(31,91,89,.32)}
 .cta-card .btn.primary:hover{background:#184645;box-shadow:0 20px 38px rgba(31,91,89,.4)}
 .cta-card h2{margin:0 0 12px;font-size:clamp(26px,3.4vw,36px)}
@@ -142,6 +156,14 @@ footer{border-top:1px solid var(--border);background:var(--bg-alt)}
   .reveal.show{opacity:1;transform:none;transition:opacity .6s ease,transform .6s ease}
   .fade-img{opacity:.001;transform:translateY(6px);will-change:opacity,transform}
   .fade-img.loaded{opacity:1;transform:none;transition:opacity .5s ease,transform .5s ease}
+  .hero-photo{animation:float 9s ease-in-out infinite}
+  .hero-card{animation:float 10s ease-in-out infinite;animation-delay:1s}
+  .hero-highlight div{animation:float 11s ease-in-out infinite;animation-delay:1.6s}
+}
+
+@keyframes float{
+  0%,100%{transform:translateY(0)}
+  50%{transform:translateY(-10px)}
 }
 
 @media (max-width:1050px){

--- a/assets/obrigado.css
+++ b/assets/obrigado.css
@@ -15,23 +15,27 @@ body{margin:0;font-family:'Manrope',system-ui,ui-sans-serif;background:var(--bg)
 a{text-decoration:none;color:inherit}
 a:visited{color:inherit}
 .container{width:min(var(--maxw),92vw);margin:0 auto}
+header .container{width:min(1180px,92vw)}
 
 header{position:sticky;top:0;z-index:140;background:rgba(244,241,236,.82);backdrop-filter:blur(16px);border-bottom:1px solid var(--border)}
 .nav{display:flex;align-items:center;justify-content:space-between;gap:24px;padding:12px 0}
 .brand{display:flex;align-items:center}
 .brand img{height:clamp(42px,10vw,74px);width:auto;display:block}
+.brand-text{font-size:clamp(20px,2.6vw,30px);font-weight:700;letter-spacing:.24em;text-transform:uppercase;color:var(--ink)}
 nav ul{list-style:none;display:flex;gap:16px;align-items:center;margin:0;padding:0;flex-wrap:wrap}
-nav a{padding:10px 14px;border-radius:999px;transition:background .2s ease;font-weight:500}
+nav a{padding:10px 14px;border-radius:999px;transition:background .2s ease;font-weight:500;color:var(--ink)}
 nav a:hover{background:rgba(24,32,34,.08)}
 .nav-cta{background:#1f5b59;color:#fff;border-radius:999px;padding:10px 18px;font-weight:600;border:1px solid #184645;box-shadow:0 10px 24px rgba(31,91,89,.28)}
 .nav-cta:hover{background:#184645}
 
 main{padding:72px 0 96px}
-.thank-card{background:#fff;border:1px solid var(--border);border-radius:var(--radius-lg);padding:32px;text-align:center;position:relative;overflow:hidden;box-shadow:var(--shadow)}
+.thank-card{background:#fff;border:1px solid var(--border);border-radius:var(--radius-lg);padding:32px;text-align:center;position:relative;overflow:hidden;box-shadow:var(--shadow);transition:transform .25s ease,box-shadow .25s ease}
+.thank-card:hover{transform:translateY(-3px);box-shadow:0 28px 70px rgba(15,23,30,.2)}
 .thank-card h1{margin:12px 0 10px;font-size:clamp(28px,3.6vw,38px)}
 .thank-card p{margin:0 0 18px;color:var(--muted)}
 .actions{display:flex;justify-content:center;gap:12px;flex-wrap:wrap;margin-bottom:10px}
-.btn{padding:12px 18px;border-radius:999px;border:1px solid var(--border);background:#fff;font-weight:600}
+.btn{padding:12px 18px;border-radius:999px;border:1px solid var(--border);background:#fff;font-weight:600;transition:transform .2s ease,box-shadow .2s ease}
+.btn:hover{transform:translateY(-1px);box-shadow:0 18px 36px rgba(15,23,30,.12)}
 .btn.primary{background:var(--accent);color:#fff;border-color:transparent}
 .btn.ghost{background:transparent;color:var(--accent)}
 .note{margin:0;color:var(--muted)}

--- a/assets/politicas.css
+++ b/assets/politicas.css
@@ -17,24 +17,28 @@ body{margin:0;font-family:'Manrope',system-ui,ui-sans-serif;background:var(--bg)
 a{text-decoration:none;color:inherit}
 a:visited{color:inherit}
 .container{width:min(var(--maxw),92vw);margin:0 auto}
+header .container{width:min(1180px,92vw)}
 
 header{position:sticky;top:0;z-index:140;background:rgba(244,241,236,.82);backdrop-filter:blur(16px);border-bottom:1px solid var(--border)}
 .nav{display:flex;align-items:center;justify-content:space-between;gap:24px;padding:12px 0}
 .brand{display:flex;align-items:center}
 .brand img{height:clamp(42px,10vw,74px);width:auto;display:block}
+.brand-text{font-size:clamp(20px,2.6vw,30px);font-weight:700;letter-spacing:.24em;text-transform:uppercase;color:var(--ink)}
 nav ul{list-style:none;display:flex;gap:16px;align-items:center;margin:0;padding:0;flex-wrap:wrap}
-nav a{padding:10px 14px;border-radius:999px;transition:background .2s ease;font-weight:500}
+nav a{padding:10px 14px;border-radius:999px;transition:background .2s ease;font-weight:500;color:var(--ink)}
 nav a:hover{background:rgba(24,32,34,.08)}
 .nav-cta{background:#1f5b59;color:#fff;border-radius:999px;padding:10px 18px;font-weight:600;border:1px solid #184645;box-shadow:0 10px 24px rgba(31,91,89,.28)}
 .nav-cta:hover{background:#184645}
 
 main{padding:72px 0 96px;display:grid;gap:18px}
-.policy-hero{background:var(--bg-alt);border:1px solid var(--border);border-radius:var(--radius-lg);padding:24px;box-shadow:var(--shadow-soft)}
+.policy-hero{background:var(--bg-alt);border:1px solid var(--border);border-radius:var(--radius-lg);padding:24px;box-shadow:var(--shadow-soft);transition:transform .25s ease,box-shadow .25s ease}
+.policy-hero:hover{transform:translateY(-3px);box-shadow:var(--shadow)}
 .policy-hero h1{margin:12px 0 10px;font-size:clamp(30px,3.6vw,40px)}
 .policy-hero p{margin:0;color:var(--muted)}
 .pill{display:inline-flex;align-items:center;gap:8px;background:var(--accent-soft);color:var(--accent);padding:6px 14px;border-radius:999px;font-weight:600;font-size:13px}
 
-.policy-card{background:#fff;border:1px solid var(--border);border-radius:var(--radius-md);padding:22px;box-shadow:var(--shadow)}
+.policy-card{background:#fff;border:1px solid var(--border);border-radius:var(--radius-md);padding:22px;box-shadow:var(--shadow);transition:transform .25s ease,box-shadow .25s ease}
+.policy-card:hover{transform:translateY(-3px);box-shadow:0 24px 56px rgba(15,23,30,.18)}
 .policy-card h2{margin:0 0 8px;font-size:20px;display:flex;gap:10px;align-items:center}
 .policy-card p{margin:0 0 12px;color:var(--muted)}
 .policy-card ul{margin:0;padding-left:18px;color:var(--muted);display:grid;gap:6px}

--- a/blog/agendas-compartilhadas-revolucione-a-rotina-da-sua-pme-hoje.html
+++ b/blog/agendas-compartilhadas-revolucione-a-rotina-da-sua-pme-hoje.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/ajuste-o-preco-certo-e-venda-mais-sem-perder-margem.html
+++ b/blog/ajuste-o-preco-certo-e-venda-mais-sem-perder-margem.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/aumente-a-fidelizacao-com-pesquisas-pos-venda-eficazes.html
+++ b/blog/aumente-a-fidelizacao-com-pesquisas-pos-venda-eficazes.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/aumente-seu-lucro-ajustando-precos-com-microtestes-rapidos.html
+++ b/blog/aumente-seu-lucro-ajustando-precos-com-microtestes-rapidos.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/aumente-sua-retencao-com-feedback-direto-via-whatsapp.html
+++ b/blog/aumente-sua-retencao-com-feedback-direto-via-whatsapp.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/automacao-no-whatsapp-que-qualifica-leads-em-menos-de-24h.html
+++ b/blog/automacao-no-whatsapp-que-qualifica-leads-em-menos-de-24h.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/automacao-pratica-para-atendimento-rapido-e-eficiente-em-pmes.html
+++ b/blog/automacao-pratica-para-atendimento-rapido-e-eficiente-em-pmes.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/cobrancas-eficientes-reduza-suas-perdas-financeiras-hoje.html
+++ b/blog/cobrancas-eficientes-reduza-suas-perdas-financeiras-hoje.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/como-enfrentar-crises-financeiras-sem-sacrificar-seus-clientes.html
+++ b/blog/como-enfrentar-crises-financeiras-sem-sacrificar-seus-clientes.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/como-ia-transforma-processos.html
+++ b/blog/como-ia-transforma-processos.html
@@ -50,7 +50,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/controle-de-contratos-evite-perdas-e-conflitos-ja.html
+++ b/blog/controle-de-contratos-evite-perdas-e-conflitos-ja.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/controle-de-estoque-que-evita-perdas-e-falta-de-produtos.html
+++ b/blog/controle-de-estoque-que-evita-perdas-e-falta-de-produtos.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/controle-de-estoque-simples-que-evita-perdas-e-falta-de-produtos.html
+++ b/blog/controle-de-estoque-simples-que-evita-perdas-e-falta-de-produtos.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/controle-de-estoques-com-fotos-evite-prejuizos-e-quebras.html
+++ b/blog/controle-de-estoques-com-fotos-evite-prejuizos-e-quebras.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/controle-diario-de-fluxo-de-caixa-evita-quebras-financeiras-reais.html
+++ b/blog/controle-diario-de-fluxo-de-caixa-evita-quebras-financeiras-reais.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/controle-financeiro-diario-o-segredo-para-evitar-surpresas.html
+++ b/blog/controle-financeiro-diario-o-segredo-para-evitar-surpresas.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/controle-rapido-e-preciso-de-entregas-pelo-whatsapp.html
+++ b/blog/controle-rapido-e-preciso-de-entregas-pelo-whatsapp.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/controle-visual-organize-seu-negocio-em-minutos-diarios.html
+++ b/blog/controle-visual-organize-seu-negocio-em-minutos-diarios.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/corte-sua-conta-de-luz-em-ate-30-sem-investir-muito.html
+++ b/blog/corte-sua-conta-de-luz-em-ate-30-sem-investir-muito.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/corte-sua-conta-de-luz-em-pmes-sem-grandes-investimentos.html
+++ b/blog/corte-sua-conta-de-luz-em-pmes-sem-grandes-investimentos.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/cronograma-de-entregas-que-evita-atrasos-e-reclamacoes.html
+++ b/blog/cronograma-de-entregas-que-evita-atrasos-e-reclamacoes.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/descubra-quem-realmente-gera-lucro-no-seu-negocio-local.html
+++ b/blog/descubra-quem-realmente-gera-lucro-no-seu-negocio-local.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/diga-adeus-ao-atraso-sistema-digital-simples-para-aprovar-orcamentos.html
+++ b/blog/diga-adeus-ao-atraso-sistema-digital-simples-para-aprovar-orcamentos.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/domine-o-whatsapp-para-transformar-clientes-em-fas-leais.html
+++ b/blog/domine-o-whatsapp-para-transformar-clientes-em-fas-leais.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/entregas-pontuais-sem-equipe-propria-em-pmes-locais.html
+++ b/blog/entregas-pontuais-sem-equipe-propria-em-pmes-locais.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/evite-burnout-cuide-da-saude-mental-do-seu-negocio-ja.html
+++ b/blog/evite-burnout-cuide-da-saude-mental-do-seu-negocio-ja.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/evite-erros-comuns-criando-protocolos-visuais-simples-e-eficientes.html
+++ b/blog/evite-erros-comuns-criando-protocolos-visuais-simples-e-eficientes.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/feedback-continuo-transforme-sua-pme-com-comunicacao-agil.html
+++ b/blog/feedback-continuo-transforme-sua-pme-com-comunicacao-agil.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/feedback-rapido-para-evitar-erros-e-atrasos-na-pme.html
+++ b/blog/feedback-rapido-para-evitar-erros-e-atrasos-na-pme.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/fluxo-simples-para-captar-clientes-b2b-em-servicos-locais.html
+++ b/blog/fluxo-simples-para-captar-clientes-b2b-em-servicos-locais.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/index.html
+++ b/blog/index.html
@@ -49,7 +49,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
       <nav aria-label="Principal">
         <ul>
@@ -71,8 +71,8 @@
         <h1>Conteúdos para lideranças que precisam de ritmo.</h1>
         <p class="lead">Insights sobre gestão de projetos, consultoria empresarial e operação para médias empresas. Conteúdos diretos para quem precisa tomar decisões com clareza.</p>
         <div class="actions">
-          <a class="btn primary" href="/contato.html" rel="nofollow"><i class="ri-mail-send-line"></i> Receber diagnóstico</a>
-          <a class="btn ghost" href="/#ultimos-artigos"><i class="ri-arrow-down-line"></i> Ver artigos</a>
+          <a class="btn primary" href="/#servicos"><i class="ri-compass-3-line"></i> Ver soluções</a>
+          <a class="btn ghost" href="#ultimos-artigos"><i class="ri-arrow-down-line"></i> Ver artigos</a>
         </div>
       </div>
     </section>

--- a/blog/microprocessos-a-chave-para-produtividade-e-lucro-imediato.html
+++ b/blog/microprocessos-a-chave-para-produtividade-e-lucro-imediato.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/monitoramento-diario-do-fluxo-de-caixa-aumenta-a-saude-financeira.html
+++ b/blog/monitoramento-diario-do-fluxo-de-caixa-aumenta-a-saude-financeira.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/nunca-mais-perca-prazos-legais-que-travam-seu-negocio.html
+++ b/blog/nunca-mais-perca-prazos-legais-que-travam-seu-negocio.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/operacao-em-90-dias.html
+++ b/blog/operacao-em-90-dias.html
@@ -50,7 +50,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/otimize-suas-vendas-usando-dados-simples-e-reais-hoje.html
+++ b/blog/otimize-suas-vendas-usando-dados-simples-e-reais-hoje.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/playbook-atendimento-ia.html
+++ b/blog/playbook-atendimento-ia.html
@@ -50,7 +50,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/politica-de-garantia-proteja-seu-servico-e-conquiste-confianca.html
+++ b/blog/politica-de-garantia-proteja-seu-servico-e-conquiste-confianca.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/precificacao-inteligente-equilibrando-custo-e-valor-na-pratica.html
+++ b/blog/precificacao-inteligente-equilibrando-custo-e-valor-na-pratica.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/promocoes-temporais-que-realmente-geram-receita-imediata.html
+++ b/blog/promocoes-temporais-que-realmente-geram-receita-imediata.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/proteja-os-dados-dos-seus-clientes-com-simplicidade.html
+++ b/blog/proteja-os-dados-dos-seus-clientes-com-simplicidade.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/reduza-inadimplencia-com-comunicacao-rapida-e-estrategica.html
+++ b/blog/reduza-inadimplencia-com-comunicacao-rapida-e-estrategica.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/reduza-inadimplencia-com-pix-e-controle-financeiro-digital.html
+++ b/blog/reduza-inadimplencia-com-pix-e-controle-financeiro-digital.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/rotinas-matinais-que-transformam-o-dia-da-sua-pme-local.html
+++ b/blog/rotinas-matinais-que-transformam-o-dia-da-sua-pme-local.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/simplifique-a-gestao-com-tecnicas-visuais-praticas-ja-aplicaveis.html
+++ b/blog/simplifique-a-gestao-com-tecnicas-visuais-praticas-ja-aplicaveis.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/teste-e-ajuste-suas-campanhas-locais-em-tempo-real.html
+++ b/blog/teste-e-ajuste-suas-campanhas-locais-em-tempo-real.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/blog/venda-mais-pelo-whatsapp-sem-perder-tempo-ou-clientes.html
+++ b/blog/venda-mais-pelo-whatsapp-sem-perder-tempo-ou-clientes.html
@@ -46,7 +46,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="../assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
             <nav aria-label="Principal">
         <ul>

--- a/contato.html
+++ b/contato.html
@@ -50,7 +50,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
       <nav aria-label="Principal">
         <ul>

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
       <nav aria-label="Principal">
         <ul>
@@ -72,7 +72,7 @@
           <li><a href="#metodologia">Metodologia</a></li>
           <li><a href="#resultados">Resultados</a></li>
           <li><a href="/blog/">Blog</a></li>
-          <li><a class="nav-cta" href="/contato.html" rel="nofollow">Falar com a Munnius</a></li>
+          <li><a class="nav-cta" href="/contato.html" rel="nofollow">Agendar conversa</a></li>
         </ul>
       </nav>
     </div>
@@ -86,8 +86,8 @@
         <h1>Gestão de projetos e consultoria empresarial para executar com ritmo.</h1>
         <p>Estruturamos processos, priorizamos portfólios e aceleramos entregas para médias empresas que precisam de previsibilidade sem perder agilidade.</p>
         <div class="hero-actions">
-          <a class="btn primary" href="/contato.html" rel="nofollow"><i class="ri-mail-send-line"></i> Agendar diagnóstico</a>
-          <a class="btn ghost" href="#servicos"><i class="ri-compass-3-line"></i> Ver soluções</a>
+          <a class="btn primary" href="#servicos"><i class="ri-compass-3-line"></i> Ver soluções</a>
+          <a class="btn ghost" href="#metodologia"><i class="ri-rocket-line"></i> Conhecer metodologia</a>
         </div>
         <div class="hero-trust">
           <span>Expertise aplicada em operações de alto impacto</span>
@@ -161,7 +161,7 @@
           <p class="kicker">Soluções</p>
           <h2>Consultorias desenhadas para médias empresas.</h2>
         </div>
-        <a class="btn ghost" href="/contato.html" rel="nofollow"><i class="ri-send-plane-line"></i> Solicitar proposta</a>
+        <a class="btn ghost" href="#metodologia"><i class="ri-flow-chart-line"></i> Ver metodologia</a>
       </div>
       <div class="grid-3">
         <article class="service-card reveal">

--- a/obrigado.html
+++ b/obrigado.html
@@ -38,7 +38,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
       <nav aria-label="Principal">
         <ul>

--- a/politicas.html
+++ b/politicas.html
@@ -50,7 +50,7 @@
   <header>
     <div class="container nav">
       <a class="brand" href="/" aria-label="Página inicial">
-        <img src="assets/logo.png" alt="Munnius">
+        <span class="brand-text">Munnius</span>
       </a>
       <nav aria-label="Principal">
         <ul>


### PR DESCRIPTION
### Motivation
- Make the header more minimal and consistent by replacing image logos with a styled site name and aligning header layout across pages. 
- Reduce CTA duplication and unify wording across the site so users see a single, consistent action in the nav and pages. 
- Fix the blog "Ver artigos" anchor and the wrapping issue in the main CTA, and add subtle motion to make the UI feel less static. 

### Description
- Replaced header logo images with a text brand element `<span class="brand-text">Munnius</span>` across `index.html`, `contato.html`, `obrigado.html`, `politicas.html` and all blog pages. 
- Standardized the nav CTA to `Agendar conversa` and simplified hero/service/blog CTAs (e.g. swapped some contact CTAs for anchor navigation such as `#servicos` and `#metodologia`) in `index.html` and `blog/index.html`. 
- Fixed the blog listing anchor so `Ver artigos` points to `#ultimos-artigos` and adjusted the blog action buttons to avoid dead links. 
- Added motion and hover polish (transitions, hover lift on cards, subtle floating animations) and adjusted CTA sizing/`white-space:nowrap` behavior in `assets/index.css`, `assets/blog.css`, `assets/contato.css`, `assets/politicas.css`, and `assets/obrigado.css`. 
- Aligned header container sizing across pages by setting `header .container{width:min(1180px,92vw)}` in relevant CSS files. 

### Testing
- Launched a local static server with `python -m http.server` and captured a full-page screenshot using Playwright; the run completed and produced `artifacts/munnius-home.png`. 
- No unit or integration test suite exists for this static site, so changes were validated via the automated screenshot run and inspection; no automated test failures were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ce760e85c8330a08ccefa4215b23a)