### PR TITLE
Disable sticky positioning for blog toolbar and post hero

### DIFF
--- a/assets/blog.css
+++ b/assets/blog.css
@@ -51,7 +51,7 @@ nav a.nav-cta{color:var(--bg)}
 .feed-head h2{margin:0;font-size:clamp(24px,3.2vw,34px)}
 .feed-head p{margin:0;color:var(--muted);max-width:50ch}
 
-.blog-toolbar{position:sticky;top:96px;z-index:120;display:grid;gap:16px;padding:18px;margin-bottom:24px;border:1px solid var(--border);border-radius:20px;background:#fff;box-shadow:var(--shadow-soft)}
+.blog-toolbar{position:static;display:grid;gap:16px;padding:18px;margin-bottom:24px;border:1px solid var(--border);border-radius:20px;background:#fff;box-shadow:var(--shadow-soft)}
 .toolbar-row{display:flex;flex-wrap:wrap;align-items:center;gap:14px}
 .toolbar-label{font-weight:600;color:var(--ink);font-size:15px;min-width:max-content}
 #blog-search{flex:1 1 240px;padding:12px 16px;border-radius:14px;border:1px solid var(--border);background:#fdfbf9;font-size:15px}
@@ -85,7 +85,7 @@ nav a.nav-cta{color:var(--bg)}
 .breadcrumbs a{color:var(--accent)}
 
 .post-hero{padding:48px;border-radius:var(--radius-lg);border:1px solid var(--border);background:#fff;box-shadow:var(--shadow);margin-bottom:32px;transition:transform .25s ease,box-shadow .25s ease}
-.blog-post .post-hero{position:sticky;top:110px;z-index:120}
+.blog-post .post-hero{position:static}
 .post-hero:hover{transform:translateY(-3px);box-shadow:0 28px 70px rgba(15,23,30,.2)}
 .post-hero .kicker{text-transform:uppercase;letter-spacing:.18em;font-size:12px;color:var(--muted);margin:0 0 10px}
 .post-hero h1{margin:0 0 18px;font-size:clamp(30px,4vw,44px)}


### PR DESCRIPTION
### Motivation
- Prevent the blog filter toolbar and the post hero/title from floating as the user scrolls so those elements remain in their normal document position.

### Description
- In `assets/blog.css` replaced `position:sticky` (and removed associated `top`/`z-index` usage) with `position:static` for `.blog-toolbar` and `.blog-post .post-hero` so the toolbar and post hero no longer stick while scrolling.

### Testing
- Started a local server with `python -m http.server 8000` and attempted a Playwright screenshot, but the Playwright run crashed (browser SIGSEGV), so no automated visual test completed; no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cf218cc508330ac41dce341bf0178)