### PR TITLE
Fix sticky blog listing header and filters

### DIFF
--- a/assets/blog.css
+++ b/assets/blog.css
@@ -47,11 +47,12 @@ nav a.nav-cta{color:var(--bg)}
 .intro .actions{display:flex;gap:12px;flex-wrap:wrap}
 
 .post-feed{padding:56px 0}
-.feed-head{display:flex;align-items:flex-end;justify-content:space-between;gap:24px;margin-bottom:28px;flex-wrap:wrap}
+.feed-sticky{position:sticky;top:var(--toolbar-offset,88px);z-index:30;display:grid;gap:16px;background:var(--bg);padding:12px 0 22px;margin-bottom:28px}
+.feed-head{display:flex;align-items:flex-end;justify-content:space-between;gap:24px;margin:0;flex-wrap:wrap}
 .feed-head h2{margin:0;font-size:clamp(24px,3.2vw,34px)}
 .feed-head p{margin:0;color:var(--muted);max-width:50ch}
 
-.blog-toolbar{position:static;display:grid;gap:16px;padding:18px;margin-bottom:24px;border:1px solid var(--border);border-radius:20px;background:#fff;box-shadow:var(--shadow-soft)}
+.blog-toolbar{position:static;display:grid;gap:16px;padding:18px;margin:0;border:1px solid var(--border);border-radius:20px;background:#fff;box-shadow:var(--shadow-soft)}
 .toolbar-row{display:flex;flex-wrap:wrap;align-items:center;gap:14px}
 .toolbar-label{font-weight:600;color:var(--ink);font-size:15px;min-width:max-content}
 #blog-search{flex:1 1 240px;padding:12px 16px;border-radius:14px;border:1px solid var(--border);background:#fdfbf9;font-size:15px}
@@ -118,7 +119,7 @@ footer{border-top:1px solid var(--border);background:var(--bg-alt)}
 }
 @media (max-width:720px){
   .post-grid{grid-template-columns:1fr}
-  .blog-toolbar{top:72px}
+  .feed-sticky{top:var(--toolbar-offset,72px)}
   .post-hero{padding:32px}
   .post-content{padding:26px}
   .footer-grid{grid-template-columns:1fr 1fr}

--- a/assets/blog.js
+++ b/assets/blog.js
@@ -76,13 +76,13 @@
     if (!toolbar) return;
     const header = document.querySelector('header');
     if (!header) {
-      toolbar.style.removeProperty('--toolbar-offset');
+      document.documentElement.style.removeProperty('--toolbar-offset');
       return;
     }
     const rect = header.getBoundingClientRect();
     const height = Math.max(rect.height, header.offsetHeight || 0);
     if (!height) return;
-    toolbar.style.setProperty('--toolbar-offset', `${Math.ceil(height + 16)}px`);
+    document.documentElement.style.setProperty('--toolbar-offset', `${Math.ceil(height + 16)}px`);
   };
 
   const syncTagButtons = () => {

--- a/blog/index.html
+++ b/blog/index.html
@@ -79,27 +79,29 @@
 
     <section class="post-feed" aria-labelledby="ultimos-artigos">
       <div class="container">
-        <div class="feed-head">
-          <h2 id="ultimos-artigos">Últimos artigos</h2>
-          <p>Explore conteúdos recentes e encontre o que faz sentido para o seu momento.</p>
-        </div>
-        <section class="blog-toolbar" id="blog-toolbar" aria-label="Ferramentas para explorar os artigos">
-          <div class="toolbar-row">
-            <label class="toolbar-label" for="blog-search">Buscar</label>
-            <input id="blog-search" name="search" type="search" placeholder="Busque por título ou resumo" autocomplete="off" />
+        <div class="feed-sticky">
+          <div class="feed-head">
+            <h2 id="ultimos-artigos">Últimos artigos</h2>
+            <p>Explore conteúdos recentes e encontre o que faz sentido para o seu momento.</p>
           </div>
-          <div class="toolbar-row toolbar-tags">
-            <span class="toolbar-label">Filtrar por temas</span>
-            <div class="tag-buttons" id="tag-filters" role="group" aria-label="Filtrar artigos por tags">
-              <span class="toolbar-hint" id="tags-loading">Carregando tags…</span>
+          <section class="blog-toolbar" id="blog-toolbar" aria-label="Ferramentas para explorar os artigos">
+            <div class="toolbar-row">
+              <label class="toolbar-label" for="blog-search">Buscar</label>
+              <input id="blog-search" name="search" type="search" placeholder="Busque por título ou resumo" autocomplete="off" />
             </div>
-            <button type="button" class="toolbar-reset" id="clear-filters" disabled aria-disabled="true" hidden>
-              <i class="ri-close-circle-line" aria-hidden="true"></i>
-              Limpar filtros
-            </button>
-          </div>
-          <p class="results-info" id="results-count" role="status" aria-live="polite">Mostrando os artigos mais recentes.</p>
-        </section>
+            <div class="toolbar-row toolbar-tags">
+              <span class="toolbar-label">Filtrar por temas</span>
+              <div class="tag-buttons" id="tag-filters" role="group" aria-label="Filtrar artigos por tags">
+                <span class="toolbar-hint" id="tags-loading">Carregando tags…</span>
+              </div>
+              <button type="button" class="toolbar-reset" id="clear-filters" disabled aria-disabled="true" hidden>
+                <i class="ri-close-circle-line" aria-hidden="true"></i>
+                Limpar filtros
+              </button>
+            </div>
+            <p class="results-info" id="results-count" role="status" aria-live="polite">Mostrando os artigos mais recentes.</p>
+          </section>
+        </div>
         <div class="post-grid" id="blog-feed">
 <!-- posts:start -->
 <article class="post-card" data-slug="teste-e-ajuste-suas-campanhas-locais-em-tempo-real">


### PR DESCRIPTION
### Motivation
- The blog listing title and filter toolbar were moving while scrolling and needed to remain fixed beneath the site header.
- The sticky offset depended on the toolbar element which made correct positioning fragile across viewports and header sizes.

### Description
- Wrap the listing heading and toolbar in a new `.feed-sticky` container in `blog/index.html` to scope the sticky behavior and keep both elements fixed together.
- Add `.feed-sticky` styles and adjust toolbar spacing in `assets/blog.css`, including responsive handling and replacing the previous toolbar top rule with `top: var(--toolbar-offset, ...)` usage.
- Update `assets/blog.js` to publish the computed offset to `document.documentElement` via the `--toolbar-offset` CSS variable in `updateToolbarOffset`, ensuring the sticky container positions correctly under the header.

### Testing
- Launched a local static server with `python -m http.server 8000` and ran a Playwright script that loaded `http://127.0.0.1:8000/blog/`, scrolled and captured a screenshot at `artifacts/blog-sticky.png`, which completed successfully.
- No unit tests exist for this static UI change and none were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cf5267e64833098df688c6aee8473)