### PR TITLE
Static JSON blog feed + client-side renderer for Home and Blog index

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -1,6 +1,165 @@
-<!DOCTYPE html><html lang="pt-BR"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Blog | Munnius</title><meta name="description" content="Insights práticos sobre gestão de projetos, operação e automação com IA."><meta property="og:title" content="Blog | Munnius"><meta property="og:description" content="Conteúdo para diretores e líderes que precisam executar melhor."><meta property="og:image" content="../og-image.png"><link rel="icon" href="../assets/favicon.svg" type="image/svg+xml"><link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500&display=swap" rel="stylesheet"><style>:root{--onyx:#0D0F12;--volt:#C8F04A;--graphite:#1E2228;--sand:#F6F5F0;--muted:#888780;--white:#fff;--body:'DM Sans',system-ui,sans-serif;--display:Georgia,serif}*{box-sizing:border-box}html{scroll-behavior:smooth}body{margin:0;font-family:var(--body);background:var(--sand);line-height:1.7}.container{width:min(1120px,92%);margin:auto}a{text-decoration:none;color:inherit}.site-header{position:fixed;inset:0 0 auto 0;z-index:40;background:rgba(13,15,18,.9)}.site-header.scrolled{backdrop-filter:blur(12px);border-bottom:1px solid rgba(200,240,74,.15)}.nav-wrap{height:78px;display:flex;justify-content:space-between;align-items:center}.logo{display:flex;align-items:center;gap:12px;font-family:Georgia,serif;color:#fff;font-size:1.5rem}.menu{display:none;gap:24px;color:#fff}.cta{background:var(--volt);padding:10px 14px;border-radius:4px;font-weight:500;color:var(--onyx)!important}.menu-btn{background:none;border:1px solid rgba(255,255,255,.25);color:#fff;padding:8px}.mobile-panel{display:none;position:fixed;inset:0;background:rgba(13,15,18,.95);padding:96px 4%}.mobile-panel.open{display:block}.mobile-panel a{display:block;color:#fff;padding:12px 0}.hero{background:var(--onyx);color:#fff;padding:150px 0 70px}.hero h1{font-family:var(--display);font-size:clamp(2.3rem,7vw,4.2rem);letter-spacing:-.03em}.section{padding:72px 0}.posts{display:grid;gap:18px}.post{background:#fff;padding:20px;border-bottom:3px solid transparent;transition:.2s}.post:hover{border-bottom-color:var(--volt)}.meta{font-size:12px;color:#5f5e5a;letter-spacing:.07em;text-transform:uppercase}.post h2{font-family:var(--display);font-size:1.7rem;letter-spacing:-.02em;margin:10px 0}.read{color:#799710;font-weight:500}.site-footer{background:var(--onyx);color:#fff;padding:56px 0}.top{display:grid;gap:20px;padding-bottom:22px;border-bottom:1px solid rgba(200,240,74,.2)}.muted{color:var(--muted)}.links{display:flex;gap:14px;flex-wrap:wrap;color:var(--muted);margin-top:16px}@media(min-width:768px){.menu{display:flex}.menu-btn{display:none}.posts,.top{grid-template-columns:repeat(2,1fr)}}#site-header{position:fixed;top:0;left:0;right:0;z-index:100;display:flex;align-items:center;justify-content:space-between;padding:0 80px;height:68px;background:rgba(13,15,18,.92);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);transition:border-bottom .3s}#site-header.scrolled{border-bottom:1px solid rgba(200,240,74,.15)}.header-logo{display:flex;align-items:center;gap:10px;text-decoration:none}.header-logo span{font-family:Georgia,serif;font-size:20px;color:#fff;letter-spacing:-.02em}#site-header nav{display:flex;gap:36px}#site-header nav a{font-family:'DM Sans',sans-serif;font-size:14px;color:#888780;text-decoration:none}.header-cta{background:#C8F04A;color:#0D0F12;padding:9px 20px;border-radius:4px;font-family:'DM Sans',sans-serif;font-size:14px;font-weight:500;text-decoration:none}.menu-toggle{display:none}#site-footer{background:#0D0F12;padding:72px 80px 40px;border-top:1px solid rgba(200,240,74,.12)}.footer-top{display:grid;grid-template-columns:1fr 1fr;gap:80px;padding-bottom:48px;border-bottom:1px solid rgba(255,255,255,.06);margin-bottom:32px}.footer-brand p{font-family:'DM Sans',sans-serif;font-size:14px;color:#5F5E5A;line-height:1.7}.footer-links{display:grid;grid-template-columns:1fr 1fr;gap:40px}.footer-links strong{display:block;font-size:11px;color:#5F5E5A;margin-bottom:16px}.footer-links a{display:block;font-size:14px;color:#888780;text-decoration:none;margin-bottom:10px}.footer-bottom{display:flex;justify-content:space-between;align-items:center}.footer-bottom p,.footer-bottom a{font-size:12px;color:#5F5E5A;text-decoration:none}@media(max-width:768px){#site-header{padding:0 24px}#site-header nav,.header-cta{display:none}.menu-toggle{display:flex;flex-direction:column;gap:5px;background:none;border:none;cursor:pointer;padding:4px}.menu-toggle span{display:block;width:22px;height:1.5px;background:#fff}#site-footer{padding:48px 24px 32px}.footer-top{grid-template-columns:1fr;gap:40px}.footer-bottom{flex-direction:column;gap:8px;text-align:center}}</style><link rel="stylesheet" href="../assets/mobile-menu.css"></head><body><header id="site-header">
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blog | Munnius</title>
+  <meta name="description" content="Insights para liderar com previsibilidade.">
+  <meta property="og:title" content="Blog | Munnius">
+  <meta property="og:description" content="Insights para liderar com previsibilidade.">
+  <meta property="og:image" content="../og-image.png">
+  <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../assets/mobile-menu.css">
+  <style>
+    * { box-sizing: border-box; }
+    body { margin: 0; background: #fff; color: #000; font-family: 'DM Sans', sans-serif; }
+    .container { width: min(1120px, 92%); margin: 0 auto; }
+    #site-header { position: fixed; top: 0; left: 0; right: 0; z-index: 100; display: flex; align-items: center; justify-content: space-between; padding: 0 80px; height: 68px; background: rgba(13,15,18,.92); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); transition: border-bottom .3s; }
+    #site-header.scrolled { border-bottom: 1px solid rgba(200,240,74,.15); }
+    .header-logo { display: flex; align-items: center; gap: 10px; text-decoration: none; }
+    .header-logo span { font-family: Georgia, serif; font-size: 20px; color: #fff; letter-spacing: -.02em; }
+    #site-header nav { display: flex; gap: 36px; }
+    #site-header nav a { font-size: 14px; color: #888780; text-decoration: none; }
+    .header-cta { background: #C8F04A; color: #0D0F12; padding: 9px 20px; border-radius: 4px; font-size: 14px; font-weight: 500; text-decoration: none; }
+    .menu-toggle { display: none; }
+    .hero { background: #000; color: #fff; padding: 150px 0 72px; }
+    .hero h1 { margin: 0 0 14px; font-family: Georgia, serif; font-size: clamp(2.1rem, 6vw, 4rem); font-weight: 400; }
+    .hero p { margin: 0; color: #d4d4d4; }
+    .section { padding: 72px 0; }
+    .posts-list { display: grid; grid-template-columns: 1fr; gap: 18px; }
+    .post-item { border: 1px solid #d9d9d9; border-radius: 12px; padding: 24px; display: flex; flex-direction: column; gap: 12px; }
+    .post-item .data-categoria { font-size: 12px; color: #4b4b4b; letter-spacing: .06em; text-transform: uppercase; }
+    .post-item h3 { margin: 0; font-family: Georgia, serif; font-size: clamp(1.4rem, 2.8vw, 1.9rem); font-weight: 400; color: #000; }
+    .post-item p { margin: 0; color: #2f2f2f; line-height: 1.6; }
+    .post-item a { color: #0B57D0; text-decoration: none; font-weight: 500; align-self: flex-start; }
+    .post-item a:hover { text-decoration: underline; }
+    .owner-instructions { margin-top: 30px; padding: 18px; background: #f5f5f5; border-left: 4px solid #0B57D0; border-radius: 8px; }
+    .owner-instructions h3 { margin: 0 0 10px; font-size: 1rem; }
+    .owner-instructions ol { margin: 0; padding-left: 18px; color: #333; }
+    #site-footer { background: #0D0F12; padding: 72px 80px 40px; border-top: 1px solid rgba(200,240,74,.12); }
+    .footer-top { display: grid; grid-template-columns: 1fr 1fr; gap: 80px; padding-bottom: 48px; border-bottom: 1px solid rgba(255,255,255,.06); margin-bottom: 32px; }
+    .footer-brand p { font-size: 14px; color: #5F5E5A; line-height: 1.7; }
+    .footer-links { display: grid; grid-template-columns: 1fr 1fr; gap: 40px; }
+    .footer-links strong { display: block; font-size: 11px; color: #5F5E5A; margin-bottom: 16px; }
+    .footer-links a { display: block; font-size: 14px; color: #888780; text-decoration: none; margin-bottom: 10px; }
+    .footer-bottom { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
+    .footer-bottom p, .footer-bottom a { font-size: 12px; color: #5F5E5A; text-decoration: none; }
+    @media (min-width: 860px) { .posts-list { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+    @media (max-width: 768px) {
+      #site-header { padding: 0 24px; }
+      #site-header nav, .header-cta { display: none; }
+      .menu-toggle { display: flex; flex-direction: column; gap: 5px; background: none; border: none; cursor: pointer; padding: 4px; }
+      .menu-toggle span { display: block; width: 22px; height: 1.5px; background: #fff; }
+      #site-footer { padding: 48px 24px 32px; }
+      .footer-top { grid-template-columns: 1fr; gap: 40px; }
+      .footer-bottom { flex-direction: column; text-align: center; }
+    }
+  </style>
+</head>
+<body>
+<header id="site-header">
   <a href="../index.html" class="header-logo"><svg width="28" height="28" viewBox="0 0 56 56" fill="none"><rect width="56" height="56" rx="10" fill="#C8F04A"/><path d="M11 44 L11 12 L28 34 L45 12 L45 44" stroke="#0D0F12" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg><span>munnius</span></a>
   <nav><a href="../sobre.html">Sobre</a><a href="../servicos.html">Serviços</a><a href="index.html">Blog</a></nav>
   <a href="../contato.html" class="header-cta">Agendar conversa →</a>
   <button class="menu-toggle" aria-label="Menu"><span></span><span></span><span></span></button>
-</header><main><section class="hero"><div class="container"><h1>Insights para liderar com previsibilidade.</h1><p>Artigos práticos sobre execução, governança e automação com IA.</p></div></section><section class="section"><div class="container posts"><article class="post"><div class="meta">20 Jan 2025 · Operações</div><h2>Plano em 90 dias para organizar sua operação</h2><p>Do diagnóstico ao rito semanal: o roteiro que usamos para destravar resultados com time enxuto e muita clareza.</p><a class="read" href="operacao-em-90-dias.html" aria-label="Ler artigo operação em 90 dias">Ler artigo →</a></article><article class="post"><div class="meta">12 Dez 2024 · IA aplicada</div><h2>Playbook de atendimento com IA para pequenas equipes</h2><p>Modelos de mensagens, integrações com n8n e métricas essenciais para atender bem sem aumentar o time.</p><a class="read" href="playbook-atendimento-ia.html" aria-label="Ler playbook de atendimento com IA">Ler artigo →</a></article><article class="post"><div class="meta">05 Fev 2025 · Gestão</div><h2>Como a IA transforma processos sem virar burocracia</h2><p>Passo a passo para mapear gargalos, priorizar automações e manter a operação leve enquanto a IA assume tarefas repetitivas.</p><a class="read" href="como-ia-transforma-processos.html" aria-label="Ler artigo como IA transforma processos">Ler artigo →</a></article></div></section></main><footer id="site-footer"><div class="footer-top"><div class="footer-brand"><a href="../index.html" class="header-logo" style="margin-bottom:12px;display:flex;"><svg width="24" height="24" viewBox="0 0 56 56" fill="none"><rect width="56" height="56" rx="10" fill="#C8F04A"/><path d="M11 44 L11 12 L28 34 L45 12 L45 44" stroke="#0D0F12" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg><span style="font-family:Georgia,serif;font-size:18px;color:#fff;margin-left:10px;letter-spacing:-0.02em;">munnius</span></a><p>Consultoria em gestão de projetos<br>e automação para médias empresas.</p></div><div class="footer-links"><div><strong>Site</strong><a href="../sobre.html">Sobre</a><a href="../servicos.html">Serviços</a><a href="index.html">Blog</a><a href="../contato.html">Contato</a></div><div><strong>Contato</strong><a href="mailto:contato@munnius.com.br">contato@munnius.com.br</a><a href="https://linkedin.com/in/grmunhoz" target="_blank">LinkedIn</a><a href="https://youtube.com/@munnius" target="_blank">YouTube</a><a href="https://instagram.com/munnius" target="_blank">Instagram</a></div></div></div><div class="footer-bottom"><p>© 2025 Munnius Consultoria — Todos os direitos reservados</p><a href="../politicas.html">Privacidade & Termos</a></div></footer><script>const header = document.getElementById('site-header');window.addEventListener('scroll', () => {header.classList.toggle('scrolled', window.scrollY > 60);});</script><script src="../assets/mobile-menu.js" defer></script></body></html>
+</header>
+
+<main>
+  <section class="hero">
+    <div class="container">
+      <h1>Insights para liderar com previsibilidade.</h1>
+      <p>Artigos práticos sobre execução, governança e automação com IA.</p>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="container">
+      <div id="blog-posts-all" class="posts-list" aria-live="polite"></div>
+      <aside class="owner-instructions" aria-label="Como publicar novo post">
+        <h3>Novo post</h3>
+        <ol>
+          <li>Crie <code>/blog/[data-slug].html</code> com layout EXATO do exemplo (breadcrumb, autor, seções).</li>
+          <li>Adicione uma nova entrada em <code>/blog/posts.json</code>.</li>
+          <li>Faça upload via GitHub/FTP e recarregue a página para atualização automática.</li>
+        </ol>
+      </aside>
+    </div>
+  </section>
+</main>
+
+<footer id="site-footer"><div class="footer-top"><div class="footer-brand"><a href="../index.html" class="header-logo" style="margin-bottom:12px;display:flex;"><svg width="24" height="24" viewBox="0 0 56 56" fill="none"><rect width="56" height="56" rx="10" fill="#C8F04A"/><path d="M11 44 L11 12 L28 34 L45 12 L45 44" stroke="#0D0F12" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg><span style="font-family:Georgia,serif;font-size:18px;color:#fff;margin-left:10px;letter-spacing:-0.02em;">munnius</span></a><p>Consultoria em gestão de projetos<br>e automação para médias empresas.</p></div><div class="footer-links"><div><strong>Site</strong><a href="../sobre.html">Sobre</a><a href="../servicos.html">Serviços</a><a href="index.html">Blog</a><a href="../contato.html">Contato</a></div><div><strong>Contato</strong><a href="mailto:contato@munnius.com.br">contato@munnius.com.br</a><a href="https://linkedin.com/in/grmunhoz" target="_blank">LinkedIn</a><a href="https://youtube.com/@munnius" target="_blank">YouTube</a><a href="https://instagram.com/munnius" target="_blank">Instagram</a></div></div></div><div class="footer-bottom"><p>© 2025 Munnius Consultoria — Todos os direitos reservados</p><a href="../politicas.html">Privacidade & Termos</a></div></footer>
+<script>
+  const header = document.getElementById('site-header');
+  window.addEventListener('scroll', () => {
+    header.classList.toggle('scrolled', window.scrollY > 60);
+  });
+</script>
+<script>
+  (async function renderBlogPosts() {
+    const homeContainer = document.getElementById('blog-posts-home');
+    const allContainer = document.getElementById('blog-posts-all');
+    if (!homeContainer && !allContainer) return;
+
+    const fallback = (container) => {
+      if (!container) return;
+      container.innerHTML = '<div class="post-item"><span class="data-categoria">Blog</span><h3>Posts em breve</h3><p>Novos conteúdos serão publicados em breve.</p></div>';
+    };
+
+    const monthMap = {
+      jan: 0, fev: 1, mar: 2, abr: 3, mai: 4, jun: 5,
+      jul: 6, ago: 7, set: 8, out: 9, nov: 10, dez: 11
+    };
+
+    const parseDate = (value) => {
+      if (!value) return 0;
+      const [day, month, year] = value.trim().toLowerCase().split(/\s+/);
+      const monthIndex = monthMap[month];
+      if (!day || monthIndex === undefined || !year) return 0;
+      return new Date(Number(year), monthIndex, Number(day)).getTime();
+    };
+
+    const buildHtml = (post) => `
+      <div class="post-item">
+        <span class="data-categoria">${post.data} · ${post.categoria}</span>
+        <h3>${post.titulo}</h3>
+        <p>${post.excerpt}</p>
+        <a href="/blog/${post.slug}">Ler artigo →</a>
+      </div>
+    `;
+
+    try {
+      const response = await fetch('/blog/posts.json', { cache: 'force-cache' });
+      if (!response.ok) throw new Error('Falha ao carregar posts.json');
+      const data = await response.json();
+      const posts = Array.isArray(data)
+        ? data.slice().sort((a, b) => parseDate(b.data) - parseDate(a.data))
+        : [];
+
+      console.log('Lista renderizada:', posts);
+
+      if (!posts.length) {
+        fallback(homeContainer);
+        fallback(allContainer);
+        return;
+      }
+
+      if (homeContainer) {
+        homeContainer.innerHTML = posts.slice(0, 3).map(buildHtml).join('');
+      }
+
+      if (allContainer) {
+        allContainer.innerHTML = posts.map(buildHtml).join('');
+      }
+    } catch (error) {
+      console.error('Erro ao renderizar posts:', error);
+      fallback(homeContainer);
+      fallback(allContainer);
+    }
+  })();
+</script>
+<script src="../assets/mobile-menu.js" defer></script>
+</body>
+</html>

--- a/blog/posts.json
+++ b/blog/posts.json
@@ -1,5 +1,26 @@
 [
-  {"slug":"operacao-em-90-dias","title":"Plano em 90 dias para organizar sua operação","excerpt":"Do diagnóstico ao rito semanal: o roteiro que usamos para destravar resultados com time enxuto e muita clareza.","published":"2025-01-20","readingMinutes":7,"tags":["Operações","Processos","Gestão"]},
-  {"slug":"playbook-atendimento-ia","title":"Playbook de atendimento com IA para pequenas equipes","excerpt":"Modelos de mensagens, integrações com n8n e métricas essenciais para atender bem sem aumentar o time.","published":"2024-12-12","readingMinutes":5,"tags":["Atendimento","IA","Automação"]},
-  {"slug":"como-ia-transforma-processos","title":"Como a IA transforma processos sem virar burocracia","excerpt":"Passo a passo para mapear gargalos, priorizar automações e manter a operação leve enquanto a IA assume tarefas repetitivas.","published":"2025-02-05","readingMinutes":6,"tags":["Processos","IA","Automação"]}
+  {
+    "titulo": "Operação em 90 dias: priorize sem travar o time",
+    "slug": "operacao-em-90-dias.html",
+    "data": "02 Abr 2026",
+    "categoria": "Operações",
+    "excerpt": "Como estruturar backlog, cadência e indicadores para acelerar entregas sem criar burocracia.",
+    "readTime": "7 min"
+  },
+  {
+    "titulo": "Playbook de atendimento com IA para PMEs",
+    "slug": "playbook-ia-atendimento.html",
+    "data": "25 Mar 2026",
+    "categoria": "IA aplicada",
+    "excerpt": "Fluxos que reduzem tempo de resposta e aumentam consistência operacional.",
+    "readTime": "5 min"
+  },
+  {
+    "titulo": "Como IA transforma processos sem burocracia",
+    "slug": "ia-processos-sem-burocracia.html",
+    "data": "18 Mar 2026",
+    "categoria": "Gestão",
+    "excerpt": "Casos diretos para ganhar visibilidade e controle em áreas críticas.",
+    "readTime": "6 min"
+  }
 ]

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     .resultados{background:#1E2228}.resultados-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:1px;background:rgba(200,240,74,.08)}.resultado-item{background:#1E2228;padding:60px 48px}.resultado-num{font-family:Georgia,serif;font-size:clamp(48px,6vw,72px);color:#C8F04A}.resultado-label{color:#888780}
     .depoimentos{background:#F6F5F0;padding:100px 80px}.eyebrow-label{font-size:11px;font-weight:500;letter-spacing:.08em;text-transform:uppercase;color:#888780}.depoimentos h2{font-family:Georgia,serif;font-size:clamp(28px,3.5vw,44px);font-weight:400;color:#0D0F12;max-width:560px;margin-bottom:56px}.depo-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:20px}.depo-card{background:#fff;border:1px solid #D3D1C7;border-radius:12px;padding:36px;display:flex;flex-direction:column;gap:28px}.depo-texto{font-family:Georgia,serif;font-size:17px;color:#1E2228;line-height:1.65;font-style:italic}.depo-texto::before{content:'\201C'}.depo-autor{display:flex;align-items:center;gap:14px}.depo-avatar{width:40px;height:40px;border-radius:50%;background:#0D0F12;color:#C8F04A;font-size:13px;display:flex;align-items:center;justify-content:center}.depo-autor strong{display:block;color:#0D0F12;font-weight:600}.depo-autor span{display:block;margin-top:6px;color:#5F5E5A;line-height:1.4}
     .fotos-clientes{background:#0D0F12;padding:100px 80px}.fotos-clientes h2{font-family:Georgia,serif;font-size:clamp(28px,3.5vw,44px);font-weight:400;color:#fff;margin-bottom:48px}.fotos-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:12px}.foto-item{position:relative;border-radius:8px;overflow:hidden;aspect-ratio:4/5}.foto-item img{width:100%;height:100%;object-fit:cover;filter:grayscale(30%) brightness(.85);transition:.4s}.foto-item:hover img{filter:grayscale(0%) brightness(1);transform:scale(1.04)}.foto-overlay{position:absolute;bottom:0;left:0;right:0;padding:20px 16px 16px;background:linear-gradient(to top,rgba(13,15,18,.85),transparent);opacity:0;transition:.3s}.foto-item:hover .foto-overlay{opacity:1}.foto-overlay span{font-size:13px;font-weight:500;letter-spacing:.08em;text-transform:uppercase;color:#C8F04A}
-    .blog-preview{background:#F6F5F0;padding:100px 80px}.blog-preview-header{display:flex;justify-content:space-between;align-items:flex-end;margin-bottom:48px;gap:24px;flex-wrap:wrap}.blog-preview-header h2{font-family:Georgia,serif;font-size:clamp(26px,3vw,38px);font-weight:400;color:#0D0F12;max-width:440px}.btn-ghost-dark{font-size:14px;color:#0D0F12;border:1px solid rgba(13,15,18,.3);padding:10px 20px;border-radius:4px;text-decoration:none}.blog-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:20px}.blog-card{background:#fff;border:1px solid #D3D1C7;border-radius:12px;padding:32px;display:flex;flex-direction:column;gap:16px}.blog-meta{display:flex;gap:12px;font-size:12px;color:#888780}.blog-cat{background:#0D0F12;color:#C8F04A;padding:3px 9px;border-radius:2px;font-size:11px}.blog-card h3{font-family:Georgia,serif;font-size:20px;font-weight:400;color:#0D0F12}.blog-card p{font-size:14px;color:#5F5E5A;line-height:1.6;flex:1}.blog-link{font-size:13px;font-weight:500;color:#C8F04A;background:#0D0F12;padding:8px 16px;border-radius:4px;text-decoration:none;align-self:flex-start}
+    .blog-preview{background:#F6F5F0;padding:100px 80px}.blog-preview-header{display:flex;justify-content:space-between;align-items:flex-end;margin-bottom:48px;gap:24px;flex-wrap:wrap}.blog-preview-header h2{font-family:Georgia,serif;font-size:clamp(26px,3vw,38px);font-weight:400;color:#0D0F12;max-width:440px}.btn-ghost-dark{font-size:14px;color:#0D0F12;border:1px solid rgba(13,15,18,.3);padding:10px 20px;border-radius:4px;text-decoration:none}.blog-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:20px}.blog-card{background:#fff;border:1px solid #D3D1C7;border-radius:12px;padding:32px;display:flex;flex-direction:column;gap:16px}.blog-meta{display:flex;gap:12px;font-size:12px;color:#888780}.blog-cat{background:#0D0F12;color:#C8F04A;padding:3px 9px;border-radius:2px;font-size:11px}.blog-card h3{font-family:Georgia,serif;font-size:20px;font-weight:400;color:#0D0F12}.blog-card p{font-size:14px;color:#5F5E5A;line-height:1.6;flex:1}.blog-link{font-size:13px;font-weight:500;color:#C8F04A;background:#0D0F12;padding:8px 16px;border-radius:4px;text-decoration:none;align-self:flex-start}.post-item{background:#fff;border:1px solid #D3D1C7;border-radius:12px;padding:32px;display:flex;flex-direction:column;gap:14px}.post-item .data-categoria{font-size:12px;color:#5F5E5A;letter-spacing:.04em;text-transform:uppercase}.post-item h3{font-family:Georgia,serif;font-size:20px;font-weight:400;color:#0D0F12;margin:0}.post-item p{font-size:14px;color:#5F5E5A;line-height:1.6;margin:0}.post-item a{font-size:13px;font-weight:500;color:#0B57D0;text-decoration:none;align-self:flex-start}.post-item a:hover{text-decoration:underline}
     .cta-final{background:#C8F04A;color:#0D0F12;padding:100px 80px;text-align:center}.cta-final h2{font-family:Georgia,serif;font-size:clamp(32px,5vw,56px);font-weight:400}.btn-dark{background:#0D0F12;color:#C8F04A;padding:16px 36px;border-radius:4px;text-decoration:none;display:inline-block}
     #site-footer{background:#0D0F12;padding:72px 80px 40px;border-top:1px solid rgba(200,240,74,.12)}.footer-top{display:grid;grid-template-columns:1fr 1fr;gap:80px;padding-bottom:48px;border-bottom:1px solid rgba(255,255,255,.06);margin-bottom:32px}.footer-links{display:grid;grid-template-columns:1fr 1fr;gap:40px}.footer-brand p,.footer-bottom p,.footer-bottom a{color:#888780;text-decoration:none}.footer-links strong{display:block;font-size:11px;color:#5F5E5A;margin-bottom:14px}.footer-links a{display:block;font-size:14px;color:#888780;text-decoration:none;margin-bottom:10px}.footer-bottom{display:flex;justify-content:space-between;align-items:center;gap:12px}
     @keyframes marquee{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
@@ -40,10 +40,73 @@
 <section class="resultados"><div class="resultados-grid"><div class="resultado-item"><div class="resultado-num">+30%</div><p class="resultado-label">redução média de retrabalho</p></div><div class="resultado-item"><div class="resultado-num">6 sem</div><p class="resultado-label">para implantar ritos e indicadores</p></div><div class="resultado-item"><div class="resultado-num">100%</div><p class="resultado-label">visibilidade executiva dos projetos</p></div><div class="resultado-item"><div class="resultado-num">72h</div><p class="resultado-label">para diagnóstico inicial</p></div></div></section>
 <section class="depoimentos"><div class="container"><p class="eyebrow-label">O que dizem</p><h2>Quem trabalhou comigo fala por mim.</h2><div class="depo-grid"><div class="depo-card"><p class="depo-texto">"Gabriel, pela sua dedicação, inteligência, competência e vontade de aprender e ensinar. Te desejo muito sucesso na sua carreira."</p><div class="depo-autor"><div class="depo-avatar">AF</div><div><strong>Ayrton Filho, PMP</strong><span>Product Owner · SCRUM Alliance</span></div></div></div><div class="depo-card"><p class="depo-texto">"Você é um grande profissional e faz muito diferença no projeto. Obrigada pela parceria e continuamos juntos em 2025."</p><div class="depo-autor"><div class="depo-avatar">SA</div><div><strong>Silvana Antônia da Silva</strong><span>Cliente · Projeto enterprise</span></div></div></div><div class="depo-card"><p class="depo-texto">"Parabéns e obrigado Munhoz! Você faz a diferença!"</p><div class="depo-autor"><div class="depo-avatar">PD</div><div><strong>Pedro Dias</strong><span>Gerente Financeiro · SAP S4</span></div></div></div><div class="depo-card"><p class="depo-texto">"Agradeço imensamente por ter tido a oportunidade de te conhecer — alguém de coração generoso, inteligente, amável e dotado de muitas qualidades."</p><div class="depo-autor"><div class="depo-avatar">EN</div><div><strong>Eduardo Neves</strong><span>Líder Técnico · Análise Funcional</span></div></div></div></div></div></section>
 <section class="fotos-clientes"><div class="container"><p class="eyebrow-label">Presença nas empresas</p><h2>Projetos reais, equipes reais.</h2><div class="fotos-grid"><div class="foto-item"><img src="assets/foto_cliente_vale.jpg" alt="Equipe do projeto Vale"/><div class="foto-overlay"><span>Vale</span></div></div><div class="foto-item"><img src="assets/foto_cliente_iveco.jpg" alt="Equipe Iveco Group"/><div class="foto-overlay"><span>Iveco Group</span></div></div><div class="foto-item"><img src="assets/foto_cliente_vale_2.jpg" alt="Equipe Vale - cliente"/><div class="foto-overlay"><span>Vale</span></div></div><div class="foto-item"><img src="assets/foto_cliente_iusa.jpg" alt="Cliente Azul"/><div class="foto-overlay"><span>Azul</span></div></div></div></div></section>
-<section class="blog-preview"><div class="container"><div class="blog-preview-header"><div><p class="eyebrow-label">Blog</p><h2>Conteúdo prático para líderes de operação.</h2></div><a href="blog/index.html" class="btn-ghost-dark">Ver todos os artigos →</a></div><div class="blog-grid"><article class="blog-card"><div class="blog-meta"><span class="blog-cat">Operações</span><span>02 Abr 2026</span></div><h3>Operação em 90 dias: priorize sem travar o time</h3><p>Como estruturar backlog, cadência e indicadores para acelerar entregas sem criar burocracia.</p><a href="blog/operacao-em-90-dias.html" class="blog-link">Ler artigo →</a></article><article class="blog-card"><div class="blog-meta"><span class="blog-cat">IA aplicada</span><span>25 Mar 2026</span></div><h3>Playbook de atendimento com IA para PMEs</h3><p>Fluxos que reduzem tempo de resposta e aumentam consistência operacional.</p><a href="blog/playbook-atendimento-ia.html" class="blog-link">Ler artigo →</a></article><article class="blog-card"><div class="blog-meta"><span class="blog-cat">Gestão</span><span>18 Mar 2026</span></div><h3>Como IA transforma processos sem burocracia</h3><p>Casos diretos para ganhar visibilidade e controle em áreas críticas.</p><a href="blog/como-ia-transforma-processos.html" class="blog-link">Ler artigo →</a></article></div></div></section>
+<section class="blog-preview"><div class="container"><div class="blog-preview-header"><div><p class="eyebrow-label">Blog</p><h2>Conteúdo prático para líderes de operação.</h2></div><a href="blog/index.html" class="btn-ghost-dark">Ver todos os artigos →</a></div><div id="blog-posts-home" class="blog-grid" aria-live="polite"></div></div></section>
 <section class="cta-final"><h2>Pronto para destravar seus projetos?</h2><p>Agende um diagnóstico gratuito e receba um plano inicial em até 72 horas.</p><a href="contato.html" class="btn-dark">Agendar conversa →</a></section>
 </main>
 <footer id="site-footer"><div class="footer-top"><div class="footer-brand"><a href="index.html" class="header-logo" style="margin-bottom:12px;display:flex;"><svg width="24" height="24" viewBox="0 0 56 56" fill="none"><rect width="56" height="56" rx="10" fill="#C8F04A"/><path d="M11 44 L11 12 L28 34 L45 12 L45 44" stroke="#0D0F12" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg><span style="font-family:Georgia,serif;font-size:18px;color:#fff;margin-left:10px;">munnius</span></a><p>Consultoria em gestão de projetos<br>e automação para médias empresas.</p></div><div class="footer-links"><div><strong>Site</strong><a href="sobre.html">Sobre</a><a href="servicos.html">Serviços</a><a href="blog/index.html">Blog</a><a href="contato.html">Contato</a></div><div><strong>Contato</strong><a href="mailto:contato@munnius.com.br">contato@munnius.com.br</a><a href="https://linkedin.com/in/grmunhoz" target="_blank">LinkedIn</a><a href="https://youtube.com/@munnius" target="_blank">YouTube</a><a href="https://instagram.com/munnius" target="_blank">Instagram</a></div></div></div><div class="footer-bottom"><p>© 2025 Munnius Consultoria — Todos os direitos reservados</p><a href="politicas.html">Privacidade & Termos</a></div></footer>
 <script>const header=document.getElementById('site-header');window.addEventListener('scroll',()=>{header.classList.toggle('scrolled',window.scrollY>60)});</script>
+<script>
+  (async function renderBlogPosts() {
+    const homeContainer = document.getElementById('blog-posts-home');
+    const allContainer = document.getElementById('blog-posts-all');
+    if (!homeContainer && !allContainer) return;
+
+    const fallback = (container) => {
+      if (!container) return;
+      container.innerHTML = '<div class="post-item"><span class="data-categoria">Blog</span><h3>Posts em breve</h3><p>Novos conteúdos serão publicados em breve.</p></div>';
+    };
+
+    const monthMap = {
+      jan: 0, fev: 1, mar: 2, abr: 3, mai: 4, jun: 5,
+      jul: 6, ago: 7, set: 8, out: 9, nov: 10, dez: 11
+    };
+
+    const parseDate = (value) => {
+      if (!value) return 0;
+      const [day, month, year] = value.trim().toLowerCase().split(/\s+/);
+      const monthIndex = monthMap[month];
+      if (!day || monthIndex === undefined || !year) return 0;
+      return new Date(Number(year), monthIndex, Number(day)).getTime();
+    };
+
+    const buildHtml = (post) => `
+      <div class="post-item">
+        <span class="data-categoria">${post.data} · ${post.categoria}</span>
+        <h3>${post.titulo}</h3>
+        <p>${post.excerpt}</p>
+        <a href="/blog/${post.slug}">Ler artigo →</a>
+      </div>
+    `;
+
+    try {
+      const response = await fetch('/blog/posts.json', { cache: 'force-cache' });
+      if (!response.ok) throw new Error('Falha ao carregar posts.json');
+      const data = await response.json();
+      const posts = Array.isArray(data)
+        ? data.slice().sort((a, b) => parseDate(b.data) - parseDate(a.data))
+        : [];
+
+      console.log('Lista renderizada:', posts);
+
+      if (!posts.length) {
+        fallback(homeContainer);
+        fallback(allContainer);
+        return;
+      }
+
+      if (homeContainer) {
+        homeContainer.innerHTML = posts.slice(0, 3).map(buildHtml).join('');
+      }
+
+      if (allContainer) {
+        allContainer.innerHTML = posts.map(buildHtml).join('');
+      }
+    } catch (error) {
+      console.error('Erro ao renderizar posts:', error);
+      fallback(homeContainer);
+      fallback(allContainer);
+    }
+  })();
+</script>
 <script src="assets/mobile-menu.js" defer></script></body>
 </html>


### PR DESCRIPTION
### Motivation
- Provide a single owner-editable static feed so new posts can be published by updating one file instead of editing multiple HTML pages. 
- Replace hard-coded blog cards with a lightweight client-side renderer that preserves the current design and keeps pages static (no public editing/forms). 

### Description
- Added `/blog/posts.json` with the requested owner-maintained schema (`titulo`, `slug`, `data`, `categoria`, `excerpt`, `readTime`) and ordered entries by date (most recent first). 
- Replaced the static blog cards in `index.html` with `<div id="blog-posts-home"></div>` and preserved the original header/footer and styles while adding `post-item` styling that matches the site design. 
- Replaced the static list in `blog/index.html` with `<div id="blog-posts-all"></div>`, included owner instructions for publishing new posts, and kept accessible/SEO elements (titles, meta). 
- Injected a universal async JS snippet at the end of pages that `fetch`es `/blog/posts.json` with `cache: 'force-cache'`, parses Portuguese month names, sorts posts by `data`, renders Top 3 on the home and all posts on the blog index using the requested HTML structure, and falls back to a "Posts em breve" message on error or empty feed; the snippet uses `try/catch` and logs `Lista renderizada` for verification. 

### Testing
- Validated JSON syntax with `python -m json.tool blog/posts.json`, which succeeded. 
- Ran a Node simulation that loaded `blog/posts.json`, rendered entries and printed validation logs (`Lista renderizada`) and counts showing `HOME_COUNT 3` and `ALL_COUNT 3`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6841e72448330bf505c96dccf1f2e)