### PR TITLE
Corrige exibição de posts inexistentes no index e página de blog

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -110,37 +110,65 @@
       return new Date(Number(year), monthIndex, Number(day)).getTime();
     };
 
+    const buildPostHref = (post) => {
+      const rawSlug = String(post?.slug || '').trim();
+      const normalizedSlug = rawSlug
+        .replace(/^\/?blog\//, '')
+        .replace(/^\//, '');
+      if (!normalizedSlug) return '';
+      return `/blog/${normalizedSlug}`;
+    };
+
+    const filterExistingPosts = async (posts) => {
+      const checks = await Promise.all(posts.map(async (post) => {
+        const href = buildPostHref(post);
+        if (!href) return null;
+
+        try {
+          const exists = await fetch(href, { method: 'HEAD', cache: 'no-store' });
+          if (!exists.ok) return null;
+          return { ...post, href };
+        } catch (error) {
+          return null;
+        }
+      }));
+
+      return checks.filter(Boolean);
+    };
+
     const buildHtml = (post) => `
       <div class="post-item">
         <span class="data-categoria">${post.data} · ${post.categoria}</span>
         <h3>${post.titulo}</h3>
         <p>${post.excerpt}</p>
-        <a href="/blog/${post.slug}">Ler artigo →</a>
+        <a href="${post.href || buildPostHref(post)}">Ler artigo →</a>
       </div>
     `;
 
     try {
-      const response = await fetch('/blog/posts.json', { cache: 'force-cache' });
+      const response = await fetch('/blog/posts.json', { cache: 'no-store' });
       if (!response.ok) throw new Error('Falha ao carregar posts.json');
       const data = await response.json();
       const posts = Array.isArray(data)
         ? data.slice().sort((a, b) => parseDate(b.data) - parseDate(a.data))
         : [];
 
-      console.log('Lista renderizada:', posts);
+      const safePosts = await filterExistingPosts(posts);
 
-      if (!posts.length) {
+      console.log('Lista renderizada:', safePosts);
+
+      if (!safePosts.length) {
         fallback(homeContainer);
         fallback(allContainer);
         return;
       }
 
       if (homeContainer) {
-        homeContainer.innerHTML = posts.slice(0, 3).map(buildHtml).join('');
+        homeContainer.innerHTML = safePosts.slice(0, 3).map(buildHtml).join('');
       }
 
       if (allContainer) {
-        allContainer.innerHTML = posts.map(buildHtml).join('');
+        allContainer.innerHTML = safePosts.map(buildHtml).join('');
       }
     } catch (error) {
       console.error('Erro ao renderizar posts:', error);

--- a/index.html
+++ b/index.html
@@ -69,37 +69,65 @@
       return new Date(Number(year), monthIndex, Number(day)).getTime();
     };
 
+    const buildPostHref = (post) => {
+      const rawSlug = String(post?.slug || '').trim();
+      const normalizedSlug = rawSlug
+        .replace(/^\/?blog\//, '')
+        .replace(/^\//, '');
+      if (!normalizedSlug) return '';
+      return `/blog/${normalizedSlug}`;
+    };
+
+    const filterExistingPosts = async (posts) => {
+      const checks = await Promise.all(posts.map(async (post) => {
+        const href = buildPostHref(post);
+        if (!href) return null;
+
+        try {
+          const exists = await fetch(href, { method: 'HEAD', cache: 'no-store' });
+          if (!exists.ok) return null;
+          return { ...post, href };
+        } catch (error) {
+          return null;
+        }
+      }));
+
+      return checks.filter(Boolean);
+    };
+
     const buildHtml = (post) => `
       <div class="post-item">
         <span class="data-categoria">${post.data} · ${post.categoria}</span>
         <h3>${post.titulo}</h3>
         <p>${post.excerpt}</p>
-        <a href="/blog/${post.slug}">Ler artigo →</a>
+        <a href="${post.href || buildPostHref(post)}">Ler artigo →</a>
       </div>
     `;
 
     try {
-      const response = await fetch('/blog/posts.json', { cache: 'force-cache' });
+      const response = await fetch('/blog/posts.json', { cache: 'no-store' });
       if (!response.ok) throw new Error('Falha ao carregar posts.json');
       const data = await response.json();
       const posts = Array.isArray(data)
         ? data.slice().sort((a, b) => parseDate(b.data) - parseDate(a.data))
         : [];
 
-      console.log('Lista renderizada:', posts);
+      const safePosts = await filterExistingPosts(posts);
 
-      if (!posts.length) {
+      console.log('Lista renderizada:', safePosts);
+
+      if (!safePosts.length) {
         fallback(homeContainer);
         fallback(allContainer);
         return;
       }
 
       if (homeContainer) {
-        homeContainer.innerHTML = posts.slice(0, 3).map(buildHtml).join('');
+        homeContainer.innerHTML = safePosts.slice(0, 3).map(buildHtml).join('');
       }
 
       if (allContainer) {
-        allContainer.innerHTML = posts.map(buildHtml).join('');
+        allContainer.innerHTML = safePosts.map(buildHtml).join('');
       }
     } catch (error) {
       console.error('Erro ao renderizar posts:', error);


### PR DESCRIPTION
### Motivation
- Evitar que a UI mostre posts "fantasmas" listados em `blog/posts.json` quando os arquivos HTML correspondentes foram removidos ou não existem mais.
- Reduzir o risco de exibição de lista desatualizada devido a cache do navegador ao carregar `posts.json`.

### Description
- Adiciona `buildPostHref(post)` para normalizar slugs e gerar links no formato `/blog/<slug>` mesmo quando o `slug` vier com prefixo.
- Introduz `filterExistingPosts(posts)` que testa cada post com uma requisição `HEAD` e mantém apenas os posts cuja URL retorna `ok` antes de renderizar.
- Altera o `fetch('/blog/posts.json')` para usar `cache: 'no-store'` e passa a usar `safePosts` no lugar de `posts` ao renderizar tanto em `index.html` quanto em `blog/index.html`.
- Mantém o fallback padrão (`Posts em breve`) quando não houver posts válidos para exibição.

### Testing
- Executado o script de edição (`python - <<'PY' ...`) para aplicar as mudanças e ele concluiu sem erro.
- Verificadas as inserções com `rg` buscando `buildPostHref|filterExistingPosts|posts.json|safePosts` e os trechos foram encontrados em `index.html` e `blog/index.html` com sucesso.
- Verificado o estado do repositório com `git status --short`, `git show --stat --oneline` e realizado o `git commit`, tudo concluído com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6929c6fb08330acd03be4f5c042d4)